### PR TITLE
fix indentation warning

### DIFF
--- a/pcm.cpp
+++ b/pcm.cpp
@@ -597,9 +597,9 @@ void print_csv_header(PCM * m,
     {
         for (uint32 i = 0; i < m->getNumCores(); ++i)
         {
-	    if (cpu_model == PCM::ATOM || cpu_model == PCM::KNL)
-		cout << "Core" << i << " (Socket" << setw(2) << m->getSocketId(i) << ");;;;;";
-	    else {
+            if (cpu_model == PCM::ATOM || cpu_model == PCM::KNL)
+                cout << "Core" << i << " (Socket" << setw(2) << m->getSocketId(i) << ");;;;;";
+            else {
                 cout << "Core" << i << " (Socket" << setw(2) << m->getSocketId(i) << ");;;;;;;;;;";
                 if (m->L3CacheOccupancyMetricAvailable())
                     cout << ';' ;
@@ -607,11 +607,11 @@ void print_csv_header(PCM * m,
                     cout << ';' ;
                 if (m->CoreRemoteMemoryBWMetricAvailable())
                     cout << ';' ;
-         }
-         for (int s = 0; s <= PCM::MAX_C_STATE; ++s)
-             if (m->isCoreCStateResidencySupported(s))
-                 cout << ";";
-             cout << ";"; // TEMP
+            }
+            for (int s = 0; s <= PCM::MAX_C_STATE; ++s)
+                if (m->isCoreCStateResidencySupported(s))
+                    cout << ";";
+            cout << ";"; // TEMP
         }
     }
 

--- a/utils.h
+++ b/utils.h
@@ -101,13 +101,22 @@ void MySystem(char * sysCmd, char ** argc);
 #pragma warning (disable : 4068 ) // disable unknown pragma warning
 #endif
 
+#ifdef __GCC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#elif defined __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverloaded-virtual"
+#endif
 struct null_stream : public std::streambuf
 {
     void overflow(char) { }
 };
+#ifdef __GCC__
+#pragma GCC diagnostic pop
+#elif defined __clang__
 #pragma clang diagnostic pop
+#endif
 
 template <class IntType>
 inline std::string unit_format(IntType n)


### PR DESCRIPTION
The indentation warning was given by g++ 6.2.0. This is really only fixing the indentation so that curly braces are in sync with the source code. CSV output test seems OK.