### PR TITLE
Use ALL object files for linking libPCM, not only the executable's ob…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ OBJS = $(COMMON_OBJS) $(EXE_OBJS)
 .PRECIOUS: $(OBJS)
 
 -include $(OBJS:.o=.d)
-libPCM.a: $(EXE_OBJS)
+libPCM.a: $(OBJS)
 	ar -rcs $@ $^
 
 %.x: %.o $(COMMON_OBJS)


### PR DESCRIPTION
…ject files.

This fixes #15 