### PR TITLE
Fix topologyEntry struct mismatch between PCM client and driver side.

### DIFF
--- a/MacMSRDriver/PcmMsr/UserKernelShared.h
+++ b/MacMSRDriver/PcmMsr/UserKernelShared.h
@@ -33,8 +33,10 @@ typedef struct {
 // The topologyEntry struct that is used by PCM
 typedef struct{
     uint32_t os_id;
-    uint32_t socket;
+    uint32_t thread_id;
     uint32_t core_id;
+    uint32_t tile_id;
+    uint32_t socket;
 } topologyEntry;
 
 // A kernel version of the topology entry structure. It has
@@ -42,26 +44,28 @@ typedef struct{
 // boundary, preventing the compiler from adding extra padding.
 typedef struct{
     uint32_t os_id;
-    uint32_t socket;
+    uint32_t thread_id;
     uint32_t core_id;
-    char padding[116];
+    uint32_t tile_id;
+    uint32_t socket;
+    char padding[108];
 } kTopologyEntry;
 
 enum {
     kOpenDriver,
     kCloseDriver,
-	kReadMSR,
+    kReadMSR,
     kWriteMSR,
     kBuildTopology,
     kGetNumInstances,
     kIncrementNumInstances,
     kDecrementNumInstances,
-	// PCI functions
-	kRead,
-	kWrite,
-	kMapMemory,
-	kUnmapMemory,
-	kReadMemory,
-    kNumberOfMethods 
+    // PCI functions
+    kRead,
+    kWrite,
+    kMapMemory,
+    kUnmapMemory,
+    kReadMemory,
+    kNumberOfMethods
 };
 #endif


### PR DESCRIPTION
There's a bug in how CPU topology data structure is filled on MacOS because of the different layout of the struct fields.  This PR fixes it.