### PR TITLE
'type' field not required when e.type is explicitly set

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -1978,7 +1978,7 @@ PCM::ErrorCode PCM::program(const PCM::ProgramMode mode_, const void * parameter
       if(canUsePerf)
       {
         e.type = PERF_TYPE_HARDWARE;
-        e.config = (((long long unsigned)PERF_TYPE_HARDWARE)<<(64ULL-8ULL)) + PERF_COUNT_HW_INSTRUCTIONS;
+        e.config = PERF_COUNT_HW_INSTRUCTIONS;
         if((perfEventHandle[i][PERF_INST_RETIRED_ANY_POS] = syscall(SYS_perf_event_open, &e, -1,
                    i /* core id */, leader_counter /* group leader */ ,0 )) <= 0)
         {
@@ -1989,7 +1989,7 @@ PCM::ErrorCode PCM::program(const PCM::ProgramMode mode_, const void * parameter
         }
         leader_counter = perfEventHandle[i][PERF_INST_RETIRED_ANY_POS];
         e.pinned = 0; // all following counter are not leaders, thus need not be pinned explicitly
-        e.config = (((long long unsigned)PERF_TYPE_HARDWARE)<<(64ULL-8ULL)) + PERF_COUNT_HW_CPU_CYCLES;
+        e.config = PERF_COUNT_HW_CPU_CYCLES;
         if( (perfEventHandle[i][PERF_CPU_CLK_UNHALTED_THREAD_POS] = syscall(SYS_perf_event_open, &e, -1,
                                                 i /* core id */, leader_counter /* group leader */ ,0 )) <= 0)
         {
@@ -1998,7 +1998,7 @@ PCM::ErrorCode PCM::program(const PCM::ProgramMode mode_, const void * parameter
           decrementInstanceSemaphore();
           return PCM::UnknownError;
         }
-        e.config = (((long long unsigned)PERF_TYPE_HARDWARE)<<(64ULL-8ULL)) + PCM_PERF_COUNT_HW_REF_CPU_CYCLES;
+        e.config = PCM_PERF_COUNT_HW_REF_CPU_CYCLES;
         if((perfEventHandle[i][PERF_CPU_CLK_UNHALTED_REF_POS] = syscall(SYS_perf_event_open, &e, -1,
                          i /* core id */, leader_counter /* group leader */ ,0 )) <= 0)
         {


### PR DESCRIPTION
When `perf_event_attr.type` (`e.type` in `cpucounters.cpp`) is explicitly set to `PERF_TYPE_HARDWARE`, the type field (bits 56-62) of `perf_event_attr.config` is not required as the kernel documentation says [here](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/design.txt#n71).

