### PR TITLE
Require -DPCM_PRINTS to cause any messages to be printed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lib: libPCM.a
 
 klocwork: $(EXE)
 
-CXXFLAGS += -std=c++1z -Wall -g -O3 -Wno-unknown-pragmas
+CXXFLAGS += -std=c++11 -Wall -g -O3 -Wno-unknown-pragmas
 
 # rely on Linux perf support (user needs CAP_SYS_ADMIN privileges), comment out to disable
 ifneq ($(wildcard /usr/include/linux/perf_event.h),)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lib: libPCM.a
 
 klocwork: $(EXE)
 
-CXXFLAGS += -Wall -g -O3 -Wno-unknown-pragmas
+CXXFLAGS += -std=c++1z -Wall -g -O3 -Wno-unknown-pragmas
 
 # rely on Linux perf support (user needs CAP_SYS_ADMIN privileges), comment out to disable
 ifneq ($(wildcard /usr/include/linux/perf_event.h),)
@@ -29,7 +29,7 @@ LIB= -pthread -lrt
 CXXFLAGS += -std=c++11
 endif
 ifeq ($(UNAME), Darwin)
-LIB= -lpthread MacMSRDriver/build/Release/libPcmMsr.dylib 
+LIB= -lpthread MacMSRDriver/build/Release/libPcmMsr.dylib
 CXXFLAGS += -I/usr/include -IMacMSRDriver -std=c++11
 endif
 ifeq ($(UNAME), FreeBSD)
@@ -70,7 +70,7 @@ libPCM.a: $(OBJS)
 	@rm -f $*.d.tmp
 
 nice:
-	uncrustify --replace -c ~/uncrustify.cfg *.cpp *.h WinMSRDriver/Win7/*.h WinMSRDriver/Win7/*.c WinMSRDriver/WinXP/*.h WinMSRDriver/WinXP/*.c  PCM_Win/*.h PCM_Win/*.cpp  
+	uncrustify --replace -c ~/uncrustify.cfg *.cpp *.h WinMSRDriver/Win7/*.h WinMSRDriver/Win7/*.c WinMSRDriver/WinXP/*.h WinMSRDriver/WinXP/*.c  PCM_Win/*.h PCM_Win/*.cpp
 
 clean:
 	rm -rf *.x *.o *~ *.d

--- a/client_bw.cpp
+++ b/client_bw.cpp
@@ -23,6 +23,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include <fcntl.h>
 #include "pci.h"
 #include "client_bw.h"
+#include "utils.h"
 
 #ifndef _MSC_VER
 #include <sys/mman.h>
@@ -83,7 +84,7 @@ ClientBW::ClientBW() : pmem(new PCMPmem())
     // std::cout << "DEBUG: imcbar="<<std::hex << imcbar <<std::endl;
     if (!imcbar)
     {
-        std::cerr << "ERROR: imcbar is zero." << std::endl;
+        pcm_cerr << "ERROR: imcbar is zero." << std::endl;
         throw std::exception();
     }
     startAddr = imcbar & (~(4096ULL - 1ULL)); // round down to 4K
@@ -186,7 +187,7 @@ ClientBW::ClientBW() :
     // std::cout << "DEBUG: imcbar="<<std::hex << imcbar <<std::endl;
     if (!imcbar)
     {
-        std::cerr << "ERROR: imcbar is zero." << std::endl;
+        pcm_cerr << "ERROR: imcbar is zero." << std::endl;
         throw std::exception();
     }
     uint64 startAddr = imcbar & (~(4096 - 1)); // round down to 4K

--- a/pci.cpp
+++ b/pci.cpp
@@ -21,6 +21,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include <sys/stat.h>
 #include <fcntl.h>
 #include "pci.h"
+#include "utils.h"
 
 #ifndef _MSC_VER
 #include <sys/mman.h>
@@ -45,7 +46,7 @@ PciHandle::PciHandle(uint32 groupnr_, uint32 bus_, uint32 device_, uint32 functi
 {
     if (groupnr_ != 0)
     {
-        std::cerr << "Non-zero PCI group segments are not supported in PCM/Windows" << std::endl;
+        pcm_cerr << "Non-zero PCI group segments are not supported in PCM/Windows" << std::endl;
         throw std::exception();
     }
 
@@ -92,7 +93,7 @@ int32 PciHandle::read32(uint64 offset, uint32 * value)
         *value = (uint32)result;
         if (!status)
         {
-            //std::cerr << "Error reading PCI Config space at bus "<<bus<<" dev "<< device<<" function "<< function <<" offset "<< offset << " size "<< req.bytes  << ". Windows error: "<<GetLastError()<<std::endl;
+            //pcm_cerr << "Error reading PCI Config space at bus "<<bus<<" dev "<< device<<" function "<< function <<" offset "<< offset << " size "<< req.bytes  << ". Windows error: "<<GetLastError()<<std::endl;
         }
         return (int32)reslength;
     }
@@ -122,7 +123,7 @@ int32 PciHandle::write32(uint64 offset, uint32 value)
         BOOL status = DeviceIoControl(hDriver, IO_CTL_PCICFG_WRITE, &req, (DWORD)sizeof(PCICFG_Request), &result, (DWORD)sizeof(uint64), &reslength, NULL);
         if (!status)
         {
-            //std::cerr << "Error writing PCI Config space at bus "<<bus<<" dev "<< device<<" function "<< function <<" offset "<< offset << " size "<< req.bytes  << ". Windows error: "<<GetLastError()<<std::endl;
+            //pcm_cerr << "Error writing PCI Config space at bus "<<bus<<" dev "<< device<<" function "<< function <<" offset "<< offset << " size "<< req.bytes  << ". Windows error: "<<GetLastError()<<std::endl;
         }
         return (int32)reslength;
     }
@@ -146,7 +147,7 @@ int32 PciHandle::read64(uint64 offset, uint64 * value)
         BOOL status = DeviceIoControl(hDriver, IO_CTL_PCICFG_READ, &req, (DWORD)sizeof(PCICFG_Request), value, (DWORD)sizeof(uint64), &reslength, NULL);
         if (!status)
         {
-            //std::cerr << "Error reading PCI Config space at bus "<<bus<<" dev "<< device<<" function "<< function <<" offset "<< offset << " size "<< req.bytes  << ". Windows error: "<<GetLastError()<<std::endl;
+            //pcm_cerr << "Error reading PCI Config space at bus "<<bus<<" dev "<< device<<" function "<< function <<" offset "<< offset << " size "<< req.bytes  << ". Windows error: "<<GetLastError()<<std::endl;
         }
         return (int32)reslength;
     }
@@ -394,7 +395,7 @@ int32 PciHandle::read64(uint64 offset, uint64 * value)
     size_t res = ::pread(fd, (void *)value, sizeof(uint64), offset);
     if(res != sizeof(uint64))
     {
-        std::cerr << " ERROR: pread from " << fd << " with offset 0x" << std::hex << offset << std::dec << " returned " << res << " bytes " << std::endl;
+        pcm_cerr << " ERROR: pread from " << fd << " with offset 0x" << std::hex << offset << std::dec << " returned " << res << " bytes " << std::endl;
     }
     return res;
 }
@@ -519,7 +520,7 @@ void PciHandleMM::readMCFG()
 
     if (mcfg_handle < 0)
     {
-        std::cerr << "PCM Error: Cannot open " << path << std::endl;
+        pcm_cerr << "PCM Error: Cannot open " << path << std::endl;
         throw std::exception();
     }
 
@@ -527,7 +528,7 @@ void PciHandleMM::readMCFG()
 
     if (read_bytes == 0)
     {
-        std::cerr << "PCM Error: Cannot read " << path << std::endl;
+        pcm_cerr << "PCM Error: Cannot read " << path << std::endl;
         throw std::exception();
     }
 
@@ -543,7 +544,7 @@ void PciHandleMM::readMCFG()
         read_bytes = ::read(mcfg_handle, (void *)&record, sizeof(MCFGRecord));
         if (read_bytes == 0)
         {
-            std::cerr << "PCM Error: Cannot read " << path << " (2)" << std::endl;
+            pcm_cerr << "PCM Error: Cannot read " << path << " (2)" << std::endl;
             throw std::exception();
         }
 #ifdef PCM_DEBUG
@@ -580,7 +581,7 @@ PciHandleMM::PciHandleMM(uint32 groupnr_, uint32 bus_, uint32 device_, uint32 fu
     }
     if (segment == mcfgRecords.size())
     {
-        std::cerr << "PCM Error: (group " << groupnr_ << ", bus " << bus_ << ") not found in the MCFG table." << std::endl;
+        pcm_cerr << "PCM Error: (group " << groupnr_ << ", bus " << bus_ << ") not found in the MCFG table." << std::endl;
         throw std::exception();
     }
     else

--- a/pcm-core.cpp
+++ b/pcm-core.cpp
@@ -208,7 +208,7 @@ void build_event(const char * argv, EventSelectRegister *reg, int idx)
 #ifdef _MSC_VER
     strncpy_s(name, argv, EVENT_SIZE - 1);
 #else
-	strncpy(name,argv,EVENT_SIZE-1); 
+	strncpy(name,argv,EVENT_SIZE-1);
 #endif
 	/*
 	   uint64 apic_int : 1;
@@ -273,7 +273,7 @@ int main(int argc, char * argv[])
 #ifdef PCM_FORCE_SILENT
 	null_stream nullStream1, nullStream2;
 	std::cout.rdbuf(&nullStream1);
-	std::cerr.rdbuf(&nullStream2);
+	pcm_cerr.rdbuf(&nullStream2);
 #endif
 
 	cerr << endl;
@@ -487,7 +487,7 @@ int main(int argc, char * argv[])
 	if (csv) {
 		if( delay<=0.0 ) delay = PCM_DELAY_DEFAULT;
 	} else {
-		// for non-CSV mode delay < 1.0 does not make a lot of practical sense: 
+		// for non-CSV mode delay < 1.0 does not make a lot of practical sense:
 		// hard to read from the screen, or
 		// in case delay is not provided in command line => set default
 		if( ((delay<1.0) && (delay>0.0)) || (delay<=0.0) ) delay = PCM_DELAY_DEFAULT;
@@ -496,7 +496,7 @@ int main(int argc, char * argv[])
 	cerr << "Update every "<<delay<<" seconds"<< endl;
 
 	std::cout.precision(2);
-	std::cout << std::fixed; 
+	std::cout << std::fixed;
 
 	BeforeTime = m->getTickCount();
 	m->getAllCounterStates(SysBeforeState, DummySocketStates, BeforeState);
@@ -566,7 +566,7 @@ int main(int argc, char * argv[])
 			if(csv)
 				cout <<i<<",";
 			else
-				cout <<" "<< setw(3) << i << "   " << setw(2) ; 
+				cout <<" "<< setw(3) << i << "   " << setw(2) ;
 			print_custom_stats(BeforeState[i], AfterState[i], csv, txn_rate);
 		}
 		if(csv)

--- a/pcm-memory.cpp
+++ b/pcm-memory.cpp
@@ -311,7 +311,7 @@ void display_bandwidth(PCM *m, memdata_t *md, uint32 no_columns)
                     \r|---------------------------------------|\n\
                     \r|--     Memory Channel Monitoring     --|\n\
                     \r|---------------------------------------|\n\
-                    \r"; 
+                    \r";
                 for(uint64 channel = 0; channel < max_imc_channels; ++channel)
                 {
                     if(md->iMC_Rd_socket_chan[skt][channel] < 0.0 && md->iMC_Wr_socket_chan[skt][channel] < 0.0) //If the channel read neg. value, the channel is not working; skip it.
@@ -445,7 +445,7 @@ void display_bandwidth_csv(PCM *m, memdata_t *md, uint64 elapsedTime)
 	             continue;
 	         cout <<setw(8) << md->EDC_Rd_socket_chan[skt][channel] << ';'
 	              <<setw(8) << md->EDC_Wr_socket_chan[skt][channel] << ';';
-	
+
 	     }
              cout <<setw(8) << md->EDC_Rd_socket[skt] <<';'
 	          <<setw(8) << md->EDC_Wr_socket[skt] <<';'
@@ -581,7 +581,7 @@ void calculate_bandwidth(PCM *m, const ServerUncorePowerState uncState1[], const
             cout << "\
                 \r|-------------------------------------------|\n\
                 \r";
-	
+
             skt += 1;
         }
     }
@@ -594,7 +594,7 @@ int main(int argc, char * argv[])
 #ifdef PCM_FORCE_SILENT
     null_stream nullStream1, nullStream2;
     std::cout.rdbuf(&nullStream1);
-    std::cerr.rdbuf(&nullStream2);
+    pcm_cerr.rdbuf(&nullStream2);
 #endif
 
 #ifdef _MSC_VER
@@ -606,7 +606,7 @@ int main(int argc, char * argv[])
     cerr << endl;
     cerr << " Processor Counter Monitor: Memory Bandwidth Monitoring Utility " << PCM_VERSION << endl;
     cerr << endl;
-    
+
     cerr << " This utility measures memory bandwidth per channel or per DIMM rank in real-time" << endl;
     cerr << endl;
 
@@ -691,13 +691,13 @@ int main(int argc, char * argv[])
                 int rank = atoi(cmd.substr(found+1).c_str());
                 if (rankA >= 0 && rankB >= 0)
                 {
-                  std::cerr << "At most two DIMM ranks can be monitored "<< std::endl;
+                  pcm_cerr << "At most two DIMM ranks can be monitored "<< std::endl;
                   exit(EXIT_FAILURE);
                 }
                 else
                 {
                   if(rank > 7) {
-                      std::cerr << "Invalid rank number "<<rank << std::endl;
+                      pcm_cerr << "Invalid rank number "<<rank << std::endl;
                       exit(EXIT_FAILURE);
                   }
                   if(rankA < 0) rankA = rank;
@@ -778,7 +778,7 @@ int main(int argc, char * argv[])
             cerr << "Access to Processor Counter Monitor has denied (Unknown error)." << endl;
             exit(EXIT_FAILURE);
     }
-    
+
     cerr << "\nDetected "<< m->getCPUBrandString() << " \"Intel(r) microarchitecture codename "<<m->getUArchCodename()<<"\""<<endl;
     if(!m->hasPCICFGUncore())
     {
@@ -809,7 +809,7 @@ int main(int argc, char * argv[])
     if (csv) {
         if( delay<=0.0 ) delay = PCM_DELAY_DEFAULT;
     } else {
-        // for non-CSV mode delay < 1.0 does not make a lot of practical sense: 
+        // for non-CSV mode delay < 1.0 does not make a lot of practical sense:
         // hard to read from the screen, or
         // in case delay is not provided in command line => set default
         if( ((delay<1.0) && (delay>0.0)) || (delay<=0.0) ) delay = PCM_DELAY_DEFAULT;
@@ -818,7 +818,7 @@ int main(int argc, char * argv[])
     cerr << "Update every "<<delay<<" seconds"<< endl;
 
     for(uint32 i=0; i<m->getNumSockets(); ++i)
-        BeforeState[i] = m->getServerUncorePowerState(i); 
+        BeforeState[i] = m->getServerUncorePowerState(i);
 
     BeforeTime = m->getTickCount();
 

--- a/pcm-msr.cpp
+++ b/pcm-msr.cpp
@@ -27,6 +27,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #ifdef _MSC_VER
 #include "freegetopt/getopt.h"
 #endif
+#include "utils.h"
 
 uint64 read_number(char * str)
 {
@@ -101,8 +102,8 @@ int main(int argc, char * argv[])
     // drv.stop();     // restart driver (usually not needed)
     if (!drv.start(driverPath))
     {
-        std::cerr << "Can not load MSR driver." << std::endl;
-        std::cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
+        pcm_cerr << "Can not load MSR driver." << std::endl;
+        pcm_cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
         return -1;
     }
     #endif
@@ -120,7 +121,7 @@ int main(int argc, char * argv[])
     }
     catch (std::exception & e)
     {
-        std::cerr << "Error accessing MSRs: " << e.what() << std::endl;
-        std::cerr << "Please check if the program can access MSR drivers." << std::endl;
+        pcm_cerr << "Error accessing MSRs: " << e.what() << std::endl;
+        pcm_cerr << "Please check if the program can access MSR drivers." << std::endl;
     }
 }

--- a/pcm-numa.cpp
+++ b/pcm-numa.cpp
@@ -100,7 +100,7 @@ int main(int argc, char * argv[])
 #ifdef PCM_FORCE_SILENT
     null_stream nullStream1, nullStream2;
     std::cout.rdbuf(&nullStream1);
-    std::cerr.rdbuf(&nullStream2);
+    pcm_cerr.rdbuf(&nullStream2);
 #endif
 
     cerr << endl;
@@ -176,12 +176,12 @@ int main(int argc, char * argv[])
     PCM::ExtendedCustomCoreEventDescription conf;
     conf.fixedCfg = NULL; // default
     conf.nGPCounters = 4;
-    
+
     try {
         m->setupCustomCoreEventsForNuma(conf);
     }
     catch (UnsupportedProcessorException& e) {
-        std::cerr << "pcm-numa tool does not support your processor currently." << std::endl;
+        pcm_cerr << "pcm-numa tool does not support your processor currently." << std::endl;
         exit(EXIT_FAILURE);
     }
 

--- a/pcm-pcie.cpp
+++ b/pcm-pcie.cpp
@@ -59,9 +59,9 @@ typedef struct
 
 typedef struct
 {
-    PCIeEvents_t total; 
-    PCIeEvents_t miss; 
-    PCIeEvents_t hit; 
+    PCIeEvents_t total;
+    PCIeEvents_t miss;
+    PCIeEvents_t hit;
 }sample_t;
 
 PCIeEvents_t aggregate_sample;
@@ -109,7 +109,7 @@ void print_usage(const string progname)
     cerr << "  -csv[=file.csv] | /csv[=file.csv]  => output compact CSV format to screen or" << endl
          << "                                        to a file, in case filename is provided" << endl;
     cerr << "  -B                                 => Estimate PCIe B/W (in Bytes/sec) by multiplying" << endl;
-    cerr << "                                        the number of transfers by the cache line size (=64 bytes)." << endl; 
+    cerr << "                                        the number of transfers by the cache line size (=64 bytes)." << endl;
     cerr << " It overestimates the bandwidth under traffic with many partial cache line transfers." << endl;
     cerr << endl;
     print_events();
@@ -129,7 +129,7 @@ int main(int argc, char * argv[])
 #ifdef PCM_FORCE_SILENT
     null_stream nullStream1, nullStream2;
     std::cout.rdbuf(&nullStream1);
-    std::cerr.rdbuf(&nullStream2);
+    pcm_cerr.rdbuf(&nullStream2);
 #endif
 
     cerr << endl;
@@ -253,7 +253,7 @@ int main(int argc, char * argv[])
             cerr << "Access to Processor Counter Monitor has denied (Unknown error)." << endl;
             exit(EXIT_FAILURE);
     }
-    
+
     cerr << "\nDetected "<< m->getCPUBrandString() << " \"Intel(r) microarchitecture codename "<<m->getUArchCodename()<<"\""<<endl;
     if(!(m->hasPCICFGUncore()))
     {
@@ -266,7 +266,7 @@ int main(int argc, char * argv[])
         cerr << "Only systems with up to "<<max_sockets<<" sockets are supported! Program aborted" << endl;
         exit(EXIT_FAILURE);
     }
-  
+
     if(m->isSomeCoreOfflined())
     {
         cerr << "Core offlining is not supported. Program aborted" << endl;
@@ -284,7 +284,7 @@ int main(int argc, char * argv[])
     if (csv) {
         if( delay<=0.0 ) delay = PCM_DELAY_DEFAULT;
     } else {
-        // for non-CSV mode delay < 1.0 does not make a lot of practical sense: 
+        // for non-CSV mode delay < 1.0 does not make a lot of practical sense:
         // hard to read from the screen, or
         // in case delay is not provided in command line => set default
         if( ((delay<1.0) && (delay>0.0)) || (delay<=0.0) ) delay = PCM_DELAY_DEFAULT;
@@ -299,14 +299,14 @@ int main(int argc, char * argv[])
     if(delay_ms * num_events * NUM_SAMPLES < delay * 1000) ++delay_ms; //Adjust the delay_ms if it's less than delay time
     sample_t sample[max_sockets];
     cerr << "delay_ms: " << delay_ms << endl;
-    
+
     if( sysCmd != NULL ) {
         MySystem(sysCmd, sysArgv);
     }
 
 	// ================================== Begin Printing Output ==================================
-	
-	
+
+
 	// additional info case
 
 
@@ -319,7 +319,7 @@ int main(int argc, char * argv[])
         MySleepMs(delay_ms);
         memset(sample,0,sizeof(sample));
         memset(&aggregate_sample,0,sizeof(aggregate_sample));
-        
+
         if(!(m->getCPUModel() == PCM::JAKETOWN) && !(m->getCPUModel() == PCM::IVYTOWN))
         {
             for(i=0;i<NUM_SAMPLES;i++)
@@ -345,7 +345,7 @@ int main(int argc, char * argv[])
                     getPCIeEvents(m, m->WiL, delay_ms, sample);
                 }
             }
-            
+
             if(csv)
                 if(print_bandwidth)
                     cout << "Skt,PCIeRdCur,RFO,CRd,DRd,ItoM,PRd,WiL,PCIe Rd (B),PCIe Wr (B)\n";
@@ -376,7 +376,7 @@ int main(int argc, char * argv[])
                         cout << "," << ((sample[i].total.ItoM + sample[i].total.RFO)*64ULL);
                     }
                     cout << "	(Total)\n";
-					
+
 					cout << i;
                     cout << "," << sample[i].miss.PCIeRdCur;
                     cout << "," << sample[i].miss.RFO;
@@ -391,7 +391,7 @@ int main(int argc, char * argv[])
                         cout << "," << ((sample[i].miss.ItoM + sample[i].miss.RFO)*64ULL);
                     }
                     cout << "	(Miss)\n";
-					
+
 					cout << i;
                     cout << "," << sample[i].hit.PCIeRdCur;
                     cout << "," << sample[i].hit.RFO;
@@ -406,8 +406,8 @@ int main(int argc, char * argv[])
                         cout << "," << ((sample[i].hit.ItoM + sample[i].hit.RFO)*64ULL);
                     }
                     cout << "	(Hit)\n";
-					
-					
+
+
                 }
                 else
                 {
@@ -425,7 +425,7 @@ int main(int argc, char * argv[])
                         cout << "        " << unit_format((sample[i].total.ItoM + sample[i].total.RFO)*64ULL);
                     }
                     cout << "	(Total)\n";
-					
+
 					cout << " " << i;
                     cout << "    " << unit_format(sample[i].miss.PCIeRdCur);
                     cout << "      " << unit_format(sample[i].miss.RFO);
@@ -440,7 +440,7 @@ int main(int argc, char * argv[])
                         cout << "        " << unit_format((sample[i].miss.ItoM + sample[i].miss.RFO)*64ULL);
                     }
                     cout << "	(Miss)\n";
-					
+
 					cout << " " << i;
                     cout << "    " << unit_format(sample[i].hit.PCIeRdCur);
                     cout << "      " << unit_format(sample[i].hit.RFO);
@@ -490,7 +490,7 @@ int main(int argc, char * argv[])
                 getPCIeEvents(m, m->PCIeNSWr, delay_ms, sample,0);
                 getPCIeEvents(m, m->PCIeNSWrF, delay_ms, sample,0);
             }
-            
+
             if(csv)
                 if(print_bandwidth)
                     cout << "Skt,PCIeRdCur,PCIeNSRd,PCIeWiLF,PCIeItoM,PCIeNSWr,PCIeNSWrF,PCIe Rd (B),PCIe Wr (B)\n";
@@ -520,7 +520,7 @@ int main(int argc, char * argv[])
                         cout << "," << ((sample[i].total.PCIeWiLF+sample[i].total.PCIeItoM+sample[i].total.PCIeNSWr+sample[i].total.PCIeNSWrF)*64ULL);
                     }
                     cout << "	(Total)\n";
-					
+
 					cout << i;
                     cout << "," << sample[i].miss.PCIeRdCur;
                     cout << "," << sample[i].miss.PCIeNSWr;
@@ -534,7 +534,7 @@ int main(int argc, char * argv[])
                         cout << "," << ((sample[i].miss.PCIeWiLF+sample[i].miss.PCIeItoM+sample[i].miss.PCIeNSWr+sample[i].miss.PCIeNSWrF)*64ULL);
                     }
                     cout << "	(Miss)\n";
-					
+
 					cout << i;
                     cout << "," << sample[i].hit.PCIeRdCur;
                     cout << "," << sample[i].hit.PCIeNSWr;
@@ -548,10 +548,10 @@ int main(int argc, char * argv[])
                         cout << "," << ((sample[i].hit.PCIeWiLF+sample[i].hit.PCIeItoM+sample[i].hit.PCIeNSWr+sample[i].hit.PCIeNSWrF)*64ULL);
                     }
                     cout << "	(Hit)\n";
-					
-					
-					
-					
+
+
+
+
                 }
                 else
                 {
@@ -568,7 +568,7 @@ int main(int argc, char * argv[])
                         cout << "         " << unit_format((sample[i].total.PCIeWiLF+sample[i].total.PCIeItoM+sample[i].total.PCIeNSWr+sample[i].total.PCIeNSWrF)*64ULL);
                     }
                     cout << "	(Total)\n";
-					
+
 					cout << " " << i;
                     cout << "      " << unit_format(sample[i].miss.PCIeRdCur);
                     cout << "      " << unit_format(sample[i].miss.PCIeNSWr);
@@ -582,7 +582,7 @@ int main(int argc, char * argv[])
                         cout << "         " << unit_format((sample[i].miss.PCIeWiLF+sample[i].miss.PCIeItoM+sample[i].miss.PCIeNSWr+sample[i].miss.PCIeNSWrF)*64ULL);
                     }
                     cout << "	(Miss)\n";
-					
+
 					cout << " " << i;
                     cout << "      " << unit_format(sample[i].hit.PCIeRdCur);
                     cout << "      " << unit_format(sample[i].hit.PCIeNSWr);
@@ -625,21 +625,21 @@ int main(int argc, char * argv[])
         }
 	++ic;
     }
-	
+
 	}
-	
-	
+
+
 	// default case
 	else if ( print_additional_info == false)
 	{
-	
+
     unsigned int ic = 1;
     while ((ic <= numberOfIterations) || (numberOfIterations == 0))
     {
         MySleepMs(delay_ms);
         memset(sample,0,sizeof(sample));
         memset(&aggregate_sample,0,sizeof(aggregate_sample));
-        
+
         if(!(m->getCPUModel() == PCM::JAKETOWN) && !(m->getCPUModel() == PCM::IVYTOWN))
         {
             for(i=0;i<NUM_SAMPLES;i++)
@@ -654,7 +654,7 @@ int main(int argc, char * argv[])
                     getPCIeEvents(m, m->SKX_PRd, delay_ms, sample, 0, m->IRQ, 1);
                     getPCIeEvents(m, m->SKX_WiL, delay_ms, sample, 0, m->IRQ, 1);
                 }
-                 else 
+                 else
                 {
                     getPCIeEvents(m, m->PCIeRdCur, delay_ms, sample);
                     getPCIeEvents(m, m->RFO, delay_ms, sample,m->RFOtid);
@@ -665,7 +665,7 @@ int main(int argc, char * argv[])
                     getPCIeEvents(m, m->WiL, delay_ms, sample);
                 }
             }
-            
+
             if(csv)
                 if(print_bandwidth)
                     cout << "Skt,PCIeRdCur,RFO,CRd,DRd,ItoM,PRd,WiL,PCIe Rd (B),PCIe Wr (B)\n";
@@ -748,7 +748,7 @@ int main(int argc, char * argv[])
                 getPCIeEvents(m, m->PCIeNSWr, delay_ms, sample,0);
                 getPCIeEvents(m, m->PCIeNSWrF, delay_ms, sample,0);
             }
-            
+
             if(csv)
                 if(print_bandwidth)
                     cout << "Skt,PCIeRdCur,PCIeNSRd,PCIeWiLF,PCIeItoM,PCIeNSWr,PCIeNSWrF,PCIe Rd (B),PCIe Wr (B)\n";
@@ -823,11 +823,11 @@ int main(int argc, char * argv[])
         }
 	++ic;
     }
-	
+
 	}
-	
+
 	// ================================== End Printing Output ==================================
-	
+
     exit(EXIT_SUCCESS);
 }
 

--- a/pcm-power.cpp
+++ b/pcm-power.cpp
@@ -144,8 +144,8 @@ int main(int argc, char * argv[])
 {
     set_signal_handlers();
 
-    std::cerr << "\n Processor Counter Monitor " << PCM_VERSION << std::endl;
-    std::cerr << "\n Power Monitoring Utility\n";
+    pcm_cerr << "\n Processor Counter Monitor " << PCM_VERSION << std::endl;
+    pcm_cerr << "\n Power Monitoring Utility\n";
 
     int imc_profile = 0;
     int pcu_profile = 0;
@@ -269,16 +269,16 @@ int main(int argc, char * argv[])
     const int cpu_model = m->getCPUModel();
     if (!(m->hasPCICFGUncore()))
     {
-        std::cerr << "Unsupported processor model (" << cpu_model << ")." << std::endl;
+        pcm_cerr << "Unsupported processor model (" << cpu_model << ")." << std::endl;
         exit(EXIT_FAILURE);
     }
 
     if (PCM::Success != m->programServerUncorePowerMetrics(imc_profile, pcu_profile, freq_band))
     {
 #ifdef _MSC_VER
-        std::cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
+        pcm_cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
 #elif defined(__linux__)
-        std::cerr << "You need to be root and loaded 'msr' Linux kernel module to execute the program. You may load the 'msr' module with 'modprobe msr'. \n";
+        pcm_cerr << "You need to be root and loaded 'msr' Linux kernel module to execute the program. You may load the 'msr' module with 'modprobe msr'. \n";
 #endif
         exit(EXIT_FAILURE);
     }
@@ -286,22 +286,22 @@ int main(int argc, char * argv[])
     ServerUncorePowerState * AfterState = new ServerUncorePowerState[m->getNumSockets()];
     uint64 BeforeTime = 0, AfterTime = 0;
 
-    std::cerr << std::dec << std::endl;
-    std::cerr.precision(2);
-    std::cerr << std::fixed;
+    pcm_cerr << std::dec << std::endl;
+    pcm_cerr << std::setprecision(2);
+    pcm_cerr << std::fixed;
     std::cout << std::dec << std::endl;
     std::cout.precision(2);
     std::cout << std::fixed;
-    std::cerr << "\nMC counter group: " << imc_profile << std::endl;
-    std::cerr << "PCU counter group: " << pcu_profile << std::endl;
+    pcm_cerr << "\nMC counter group: " << imc_profile << std::endl;
+    pcm_cerr << "PCU counter group: " << pcu_profile << std::endl;
     if (pcu_profile == 0) {
         if (cpu_model == PCM::HASWELLX || cpu_model == PCM::BDX_DE || cpu_model == PCM::SKX)
-            std::cerr << "Your processor does not support frequency band statistics" << std::endl;
+            pcm_cerr << "Your processor does not support frequency band statistics" << std::endl;
         else
-            std::cerr << "Freq bands [0/1/2]: " << freq_band[0] * 100 << " MHz; " << freq_band[1] * 100 << " MHz; " << freq_band[2] * 100 << " MHz; " << std::endl;
+            pcm_cerr << "Freq bands [0/1/2]: " << freq_band[0] * 100 << " MHz; " << freq_band[1] * 100 << " MHz; " << freq_band[2] * 100 << " MHz; " << std::endl;
     }
     if (sysCmd != NULL)
-        std::cerr << "Update every " << delay << " seconds" << std::endl;
+        pcm_cerr << "Update every " << delay << " seconds" << std::endl;
 
     if ((sysCmd != NULL) && (delay <= 0.0)) {
         // in case external command is provided in command line, and
@@ -419,7 +419,7 @@ int main(int argc, char * argv[])
             case 1:
                 std::cout << "S" << socket
                           << "; PCUClocks: " << getPCUClocks(BeforeState[socket], AfterState[socket])
-                          << ((cpu_model == PCM::SKX)?"; core C0_1/C3/C6_7-state residency: ":"; core C0/C3/C6-state residency: ") 
+                          << ((cpu_model == PCM::SKX)?"; core C0_1/C3/C6_7-state residency: ":"; core C0/C3/C6-state residency: ")
                           << getNormalizedPCUCounter(1, BeforeState[socket], AfterState[socket])
                           << "; " << getNormalizedPCUCounter(2, BeforeState[socket], AfterState[socket])
                           << "; " << getNormalizedPCUCounter(3, BeforeState[socket], AfterState[socket])

--- a/pcm-tsx.cpp
+++ b/pcm-tsx.cpp
@@ -188,7 +188,7 @@ int main(int argc, char * argv[])
 #ifdef PCM_FORCE_SILENT
     null_stream nullStream1, nullStream2;
     std::cout.rdbuf(&nullStream1);
-    std::cerr.rdbuf(&nullStream2);
+    pcm_cerr.rdbuf(&nullStream2);
 #endif
 
     cerr << endl;

--- a/pcm.cpp
+++ b/pcm.cpp
@@ -1004,13 +1004,13 @@ int main(int argc, char * argv[])
 #ifdef PCM_FORCE_SILENT
     null_stream nullStream1, nullStream2;
     std::cout.rdbuf(&nullStream1);
-    std::cerr.rdbuf(&nullStream2);
+    pcm_cerr.rdbuf(&nullStream2);
 #endif
 
     cerr << endl;
     cerr << " Processor Counter Monitor " << PCM_VERSION << endl;
     cerr << endl;
-    
+
     cerr << endl;
 
     // if delay is not specified: use either default (1 second),

--- a/utils.h
+++ b/utils.h
@@ -30,6 +30,31 @@ CT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 #include <time.h>
 #include "types.h"
 
+class ostreamWrapper {
+private:
+    std::ostream* str;
+
+public:
+    ostreamWrapper(std::ostream* str_v) : str(str_v) {}
+
+    template <typename T>
+    ostreamWrapper& operator<<(const T& t) {
+        #if defined(PCM_PRINTS)
+        *str << std::forward<T>(t);
+        #endif
+        return *this;
+    }
+
+    ostreamWrapper& operator<<(std::ostream& (*manip)(std::ostream&)) {
+        #if defined(PCM_PRINTS)
+        *str << manip;
+        #endif
+        return *this;
+    }
+};
+
+extern ostreamWrapper pcm_cerr;
+
 #ifndef _MSC_VER
 #include <csignal>
 #include <ctime>


### PR DESCRIPTION
Hi all,

I am trying to use PCM to perform some profile-guided optimization of SIMD vector code in a compiler back-end. There are a lot of calls to std::cerr which happen unconditionally all over the place. These are introducing a lot of noise into my measurement, because I'm trying to get cycle-accurate numbers, or as close as possible.

With these calls suitable guarded, PCM delivers the accuracy I need. I have made it so that passing -DPCM_PRINTS yields the old behaviour by using a zero-cost template wrapper for std::cerr. These changes might enable other folks to get more accurate numbers from PCM. Changes and modifications are of course welcome, if there is a better way to do this I'd be happy to change the code to your liking.

I should clarify: the existing PCM_FORCE_SILENT macro does not actually result in the code which performs the prints being compiled out, but rather uses a null stream as the endpoint for std::cout and std::cerr. The compiler still emits code for all occurrences of operator<< with this arrangement (GCC 7.2 x86_64 linux gnu). However, if you wrap the stream and make sure that the body of the operators consists only of a return statement, the compiler actually eliminates these calls, and the associated measurement noise.