### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -341,6 +341,9 @@ namespace PCMServiceNS {
             }
             // Here we now have the chance to do cleanup after catching the ThreadAbortException because of the ResetAbort
             m_->cleanup();
+
+			delete[] oldSocketStates;
+			delete[] oldCoreStates;
         }
 
     private:

--- a/pcm-iio.cpp
+++ b/pcm-iio.cpp
@@ -131,6 +131,7 @@ vector<string> combine_stack_name_and_counter_names(string stack_name)
         v.push_back(tmp[i]);
     }
 
+	delete[] tmp;
     return v;
 }
 

--- a/pcm-pcie.cpp
+++ b/pcm-pcie.cpp
@@ -947,4 +947,6 @@ void getPCIeEvents(PCM *m, PCM::PCIeEventCode opcode, uint32 delay_ms, sample_t 
 
     delete[] before;
     delete[] after;
+	delete[] before2;
+	delete[] after2;
 }

--- a/pcm.cpp
+++ b/pcm.cpp
@@ -1101,7 +1101,7 @@ int main(int argc, char * argv[])
             continue;
         }
         else
-        if (strncmp(*argv, "--nosystem", 9) == 0 ||
+        if (strncmp(*argv, "--nosystem", 10) == 0 ||
             strncmp(*argv, "-nsys", 5) == 0 ||
             strncmp(*argv, "/nsys", 5) == 0)
         {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V666](https://www.viva64.com/en/w/v666/) Consider inspecting third argument of the function 'strncmp'. It is possible that the value does not correspond with the length of a string which was passed with the second argument. pcm.cpp 1104
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'before2' pointer was exited without releasing the memory. A memory leak is possible. pcm-pcie.cpp 950
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'after2' pointer was exited without releasing the memory. A memory leak is possible. pcm-pcie.cpp 950
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'oldSocketStates' pointer was exited without releasing the memory. A memory leak is possible. pcmservice.h 344
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'oldCoreStates' pointer was exited without releasing the memory. A memory leak is possible. pcmservice.h 344
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'tmp' pointer. A memory leak is possible. pcm-iio.cpp 134