### PR TITLE
pcm and pcm-memory: output cleanups

### DIFF
--- a/pcm-memory.cpp
+++ b/pcm-memory.cpp
@@ -95,6 +95,7 @@ void print_help(const string prog_name)
 
 void printSocketBWHeader(uint32 no_columns, uint32 skt)
 {
+    cout << "\033[3;J\033[H\033[J";
     for (uint32 i=skt; i<(no_columns+skt); ++i) {
         cout << "|---------------------------------------|";
     }

--- a/pcm.cpp
+++ b/pcm.cpp
@@ -207,7 +207,7 @@ void print_output(PCM * m,
                     "    " << getActiveRelativeFrequency(cstates1[i], cstates2[i]) <<
                     "    " << unit_format(getL3CacheMisses(cstates1[i], cstates2[i])) <<
                     "   " << unit_format(getL2CacheMisses(cstates1[i], cstates2[i])) <<
-                    "    " << getL3CacheHitRatio(cstates1[i], cstates2[i]) <<
+                    "  " << getL3CacheHitRatio(cstates1[i], cstates2[i]) <<
                     "    " << getL2CacheHitRatio(cstates1[i], cstates2[i]) <<
                     "    " << double(getL3CacheMisses(cstates1[i], cstates2[i])) / getInstructionsRetired(cstates1[i], cstates2[i]) <<
                     "    " << double(getL2CacheMisses(cstates1[i], cstates2[i])) / getInstructionsRetired(cstates1[i], cstates2[i]) ;
@@ -236,7 +236,7 @@ void print_output(PCM * m,
                     "    " << getActiveRelativeFrequency(sktstate1[i], sktstate2[i]) <<
                     "    " << unit_format(getL3CacheMisses(sktstate1[i], sktstate2[i])) <<
                     "   " << unit_format(getL2CacheMisses(sktstate1[i], sktstate2[i])) <<
-                    "    " << getL3CacheHitRatio(sktstate1[i], sktstate2[i]) <<
+                    "  " << getL3CacheHitRatio(sktstate1[i], sktstate2[i]) <<
                     "    " << getL2CacheHitRatio(sktstate1[i], sktstate2[i]) <<
                     "    " << double(getL3CacheMisses(sktstate1[i], sktstate2[i])) / getInstructionsRetired(sktstate1[i], sktstate2[i]) <<
                     "    " << double(getL2CacheMisses(sktstate1[i], sktstate2[i])) / getInstructionsRetired(sktstate1[i], sktstate2[i]);
@@ -278,7 +278,7 @@ void print_output(PCM * m,
                 "    " << getActiveRelativeFrequency(sstate1, sstate2) <<
                 "    " << unit_format(getL3CacheMisses(sstate1, sstate2)) <<
                 "   " << unit_format(getL2CacheMisses(sstate1, sstate2)) <<
-                "    " << getL3CacheHitRatio(sstate1, sstate2) <<
+                "  " << getL3CacheHitRatio(sstate1, sstate2) <<
                 "    " << getL2CacheHitRatio(sstate1, sstate2) <<
                 "    " << double(getL3CacheMisses(sstate1, sstate2)) / getInstructionsRetired(sstate1, sstate2) <<
                 "    " << double(getL2CacheMisses(sstate1, sstate2)) / getInstructionsRetired(sstate1, sstate2);


### PR DESCRIPTION
From: Robert Elliott <elliott@hpe.com>

Clear the screen before each update, so the numbers update in place
(provided the window is big enough to fit the whole output).