### PR TITLE
Appease GCC: snprintf outut size larger than destination size

### DIFF
--- a/pcm-iio.cpp
+++ b/pcm-iio.cpp
@@ -153,8 +153,8 @@ vector<struct data> prepare_data(const vector<uint64_t> &values, const vector<st
 string build_pci_header(const PCIDB & pciDB, uint32_t column_width, struct pci p, int part = -1, uint32_t level = 0)
 {
     string s = "|";
-    char bdf_buf[8];
-    char speed_buf[9];
+    char bdf_buf[10];
+    char speed_buf[10];
     char vid_did_buf[10];
     char device_name_buf[128];
 


### PR DESCRIPTION
GCC ignores that PCI function numbers range from 0 to 7, generations are
up to 4 (5, by 2019 Q2) and link speeds are up to 16x. So it warns that
snprintf output may be truncated in build_pci_header (in pcm-iio.cpp).

Solve this by increasing the buffer sizes, since the additional three
bytes are harmless. We could satisfy GCC by masking p.bdf.funcno and
p.link_speed to 0x07, thus limitting the output to one decimal digit,
and p.link_width to 0x1f (two decimal digits). This approach, however,
would hide invalid arguments, preventing the user from noticing the
error.

Signed-off-by: Carlos Santos <casantos@datacom.ind.br>