### PR TITLE
Add *.a to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.x
 *.d
+*.a
 *.xml
 /.project
 *.XML

--- a/Makefile
+++ b/Makefile
@@ -73,4 +73,4 @@ nice:
 	uncrustify --replace -c ~/uncrustify.cfg *.cpp *.h WinMSRDriver/Win7/*.h WinMSRDriver/Win7/*.c WinMSRDriver/WinXP/*.h WinMSRDriver/WinXP/*.c  PCM_Win/*.h PCM_Win/*.cpp  
 
 clean:
-	rm -rf *.x *.o *~ *.d
+	rm -rf *.x *.o *~ *.d *.a


### PR DESCRIPTION
Adding *.a to .gitignore to prevent libPCM.a build target from being committed to repository.  Makes .a extensions consistent with other generated file extensions such as .d and .x