### PR TITLE
PCM: fix proper destruction

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -40,6 +40,7 @@ void exit_cleanup(void)
 
     // this replaces same call in cleanup() from util.h
     PCM::getInstance()->cleanup(); // this replaces same call in cleanup() from util.h
+    delete PCM::getInstance();
 
 //TODO: delete other shared objects.... if any.
 

--- a/width_extender.h
+++ b/width_extender.h
@@ -26,6 +26,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "client_bw.h"
 #include "mutex.h"
 #include <memory>
+
+#ifdef __linux__
+#include <mutex>
+#include <condition_variable>
+#endif
+
 #ifndef _MSC_VER
 // the header can not be included into code using CLR
 #include <thread>
@@ -127,6 +133,8 @@ public:
 private:
     std::thread * UpdateThread;
     bool updateThreadStop;
+    std::mutex updateThreadMutex;
+    std::condition_variable updateThreadCondVar;
 
     PCM_Util::Mutex CounterMutex;
 

--- a/width_extender.h
+++ b/width_extender.h
@@ -126,6 +126,7 @@ public:
 
 private:
     std::thread * UpdateThread;
+    bool updateThreadStop;
 
     PCM_Util::Mutex CounterMutex;
 


### PR DESCRIPTION
This commit enables clean deletion of the PCM object and/or unloading
libpcm.so, which was not possible in the past.

Prior to this commit, upon attempt at PCM object destruction the whole
program would've been aborted. This is due to termination of threads
without properly joining them.
As a result, the PCM object could not be destroyed once created, or
libpcm.so could not be unloaded once loaded.

This commit takes care of joining PCM threads upon object destruction.

Signed-off-by: Andrey Gelman <andrey.gelman@datarcs.com>