### PR TITLE
Fix PciHandle::write32 on FreeBSD

### DIFF
--- a/msr.cpp
+++ b/msr.cpp
@@ -179,10 +179,13 @@ MsrHandle::~MsrHandle()
 int32 MsrHandle::write(uint64 msr_number, uint64 value)
 {
     cpuctl_msr_args_t args;
+    int ret;
 
     args.msr = msr_number;
     args.data = value;
-    return ::ioctl(fd, CPUCTL_WRMSR, &args);
+    ret = ::ioctl(fd, CPUCTL_WRMSR, &args);
+    if (ret) return ret;
+    return sizeof(value);
 }
 
 int32 MsrHandle::read(uint64 msr_number, uint64 * value)
@@ -192,8 +195,9 @@ int32 MsrHandle::read(uint64 msr_number, uint64 * value)
 
     args.msr = msr_number;
     ret = ::ioctl(fd, CPUCTL_RDMSR, &args);
-    if (!ret) *value = args.data;
-    return ret;
+    if (ret) return ret;
+    *value = args.data;
+    return sizeof(*value);
 }
 
 #else

--- a/pci.cpp
+++ b/pci.cpp
@@ -281,15 +281,16 @@ int32 PciHandle::read32(uint64 offset, uint32 * value)
     pi.pi_width = 4;
 
     ret = ioctl(fd, PCIOCREAD, &pi);
+    if (ret) return ret;
 
-    if (!ret) *value = pi.pi_data;
-
-    return ret;
+    *value = pi.pi_data;
+    return sizeof(*value);
 }
 
 int32 PciHandle::write32(uint64 offset, uint32 value)
 {
     struct pci_io pi;
+    int ret;
 
     pi.pi_sel.pc_domain = 0;
     pi.pi_sel.pc_bus = bus;
@@ -299,7 +300,10 @@ int32 PciHandle::write32(uint64 offset, uint32 value)
     pi.pi_width = 4;
     pi.pi_data = value;
 
-    return ioctl(fd, PCIOCWRITE, &pi);
+    ret = ioctl(fd, PCIOCWRITE, &pi);
+    if (ret) return ret;
+
+    return sizeof(value);
 }
 
 int32 PciHandle::read64(uint64 offset, uint64 * value)
@@ -325,7 +329,7 @@ int32 PciHandle::read64(uint64 offset, uint64 * value)
     if (ret) return ret;
 
     *value += ((uint64)pi.pi_data << 32);
-    return 0;
+    return sizeof(value);
 }
 
 PciHandle::~PciHandle()


### PR DESCRIPTION
FreeBSD's PCIOCWRITE ioctl returns 0 on success, but the API
used here wants the length written to the register returned on
success.  Without this fix, any register writes seemed to fail.
This fixes QPI intformation on FreeBSD.