### PR TITLE
fix error C3861: '__rdtscp': identifier not found

### DIFF
--- a/cpucounters.h
+++ b/cpucounters.h
@@ -67,6 +67,9 @@ class PCM;
 class CoreTaskQueue;
 
 #ifdef _MSC_VER
+#if _MSC_VER>= 1600
+#include <intrin.h>
+#endif
 void PCM_API restrictDriverAccess(LPCWSTR path);
 #endif
 


### PR DESCRIPTION
with VS2017 you get this error when including cpucounters.h