### PR TITLE
Add hires timestamp to CSV

### DIFF
--- a/pcm.cpp
+++ b/pcm.cpp
@@ -464,7 +464,7 @@ void print_csv_header(PCM * m,
     )
 {
     // print first header line
-    cout << "System;;";
+    cout << "System;;;";
     if (show_system_output)
     {
     	if (cpu_model == PCM::ATOM || cpu_model == PCM::KNL)
@@ -613,7 +613,8 @@ void print_csv_header(PCM * m,
     }
 
     // print second header line
-    cout << "\nDate;Time;";
+    cout << "\nDate;Time;TimeStamp;";
+
     if (show_system_output)
     {
         if (cpu_model == PCM::ATOM || cpu_model == PCM::KNL)
@@ -776,6 +777,7 @@ void print_csv(PCM * m,
     const bool show_system_output
     )
 {
+    double ts = pcm_timestamp();
 #ifndef _MSC_VER
     struct timeval timestamp;
     gettimeofday(&timestamp, NULL);
@@ -791,6 +793,9 @@ void print_csv(PCM * m,
 #else
         << "." << setw(3) << ceil(timestamp.tv_usec / 1000) << ';';
 #endif
+    cout.precision(6);
+    cout << std::setw(16) << std::fixed << ts << ";" << setw(3);
+    cout.precision(3);
     cout.fill(old_fill);
 
     if (show_system_output)

--- a/utils.h
+++ b/utils.h
@@ -97,6 +97,8 @@ inline void MySleepUs(int delay_us)
 }
 
 void MySystem(char * sysCmd, char ** argc);
+double pcm_timestamp(void);
+
 
 #ifdef _MSC_VER
 #pragma warning (disable : 4068 ) // disable unknown pragma warning


### PR DESCRIPTION
Currently the PCM CSV has a timestamp with a 1 second resolution.
In order to correlate the PCM data with other data sources it
would be helpful to have a higher resolution timestamp.
This patch adds a timestamp which can be correlated with linux
perf or trace-cmd data or with ETW trace data.
perf and trace-cmd can be told to use the clock_gettime
CLOCK_MONOTONIC clock so that timestamp is used here for Linux.
Windows ETW uses GetSystemTimePreciseAsFileTime or
GetSystemTimeAsFileTime (on Win7 and before) so the patch uses
that timestamp on Windows. GetSystemTime is relatively slow so
after the 1st call to GetSystemTime* the QueryPerformanceCounter
API is used to get a time delta. The delta is added to the initial
GetSystemTime* value to get an absolute timestamp.