### PR TITLE
The type field of perf_event_attr.config must not be used when the raw_type field is 1

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -2095,7 +2095,7 @@ PCM::ErrorCode PCM::program(const PCM::ProgramMode mode_, const void * parameter
             if(canUsePerf)
             {
                 e.type = PERF_TYPE_RAW;
-                e.config = (1ULL<<63ULL) + (((long long unsigned)PERF_TYPE_RAW)<<(64ULL-8ULL)) + event_select_reg.value;
+		e.config = (1ULL<<63ULL) + event_select_reg.value;
                 if (event_select_reg.fields.event_select == OFFCORE_RESPONSE_0_EVTNR)
                     e.config1 = pExtDesc->OffcoreResponseMsrValue[0];
                 if (event_select_reg.fields.event_select == OFFCORE_RESPONSE_1_EVTNR)


### PR DESCRIPTION
When the `raw_type` field of `perf_event_attr.config` is 1, all other 63 bits are used to specify the value to be set to the `IA32_PERFEVTSELx` MSR, as the [kernel documentation](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/design.txt#n70) explains.

```
The 'config' field specifies what the counter should count.  It
is divided into 3 bit-fields:

raw_type: 1 bit   (most significant bit)	0x8000_0000_0000_0000
type:	  7 bits  (next most significant)	0x7f00_0000_0000_0000
event_id: 56 bits (least significant)		0x00ff_ffff_ffff_ffff

If 'raw_type' is 1, then the counter will count a hardware event
specified by the remaining 63 bits of event_config.  The encoding is
machine-specific.
```

The current version still works because the upper bits of the `IA32_PERFEVTSELx` MSR are just reserved and never actually used.