### PR TITLE
Make pcm-numa work for Skylake-based Xeon processors

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -5522,9 +5522,9 @@ void PCM::setupCustomCoreEventsForNuma(PCM::ExtendedCustomCoreEventDescription& 
         break;
     case PCM::SKX:
         // OFFCORE_RESPONSE.ALL_REQUESTS.L3_MISS_LOCAL_DRAM.ANY_SNOOP
-        conf.OffcoreResponseMsrValue[0] = 0x3FC0009FFF | (1 << 26);
+        conf.OffcoreResponseMsrValue[0] = 0x3FC0008FFF | (1 << 26);
         // OFFCORE_RESPONSE.ALL_REQUESTS.L3_MISS_REMOTE_(HOP0,HOP1,HOP2P)_DRAM.ANY_SNOOP
-        conf.OffcoreResponseMsrValue[1] = 0x3FC0009FFF | (1 << 27) | (1 << 28) | (1 << 29);
+        conf.OffcoreResponseMsrValue[1] = 0x3FC0008FFF | (1 << 27) | (1 << 28) | (1 << 29);
         break;
     default:
         throw UnsupportedProcessorException();


### PR DESCRIPTION
The current version of `pcm-numa` does not work for Skylake-based Xeon processors when `PCM_USE_PERF` is used due to an `EINVAL` returned by `perf_event_open`.

The reason is `cpucounter.cpp` mistakenly sets a reserved bit and the kernel checks the validity of the value using a "strict" mask, which requires reserved bits to be zero.

The mask is `0x3fffff8fff` and defined [here](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/x86/events/intel/core.c?h=v4.9.135#n229). The current values of `conf.OffcoreResponseMsrValue[0]` and `conf.OffcoreResponseMsrValue[1]` have conflicts with this mask and this patch fixes this problem.
