### PR TITLE
daemon.cpp: use C++ assignment to zero-out struct, not memset

### DIFF
--- a/daemon/daemon/daemon.cpp
+++ b/daemon/daemon/daemon.cpp
@@ -374,7 +374,7 @@ namespace PCMDaemon {
 		}
 
 		//Clear out shared memory
-		std::memset(sharedPCMState_, 0, sizeof(SharedPCMState));
+		*sharedPCMState_ = {};
 	}
 
 	gid_t Daemon::resolveGroupName(const std::string& groupName)


### PR DESCRIPTION
Prevents a warning from GCC 8:

Building file: ../daemon.cpp
Invoking: GCC C++ Compiler
g++ -O0 -g3 -Wall -c -fmessage-length=0 -Wno-unknown-pragmas -std=c++0x -MMD -MP -MF"daemon.d" -MT"daemon.d" -o "daemon.o" "../daemon.cpp"
../daemon.cpp: In member function ‘void PCMDaemon::Daemon::setupSharedMemory()’:
../daemon.cpp:377:57: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘PCMDaemon::SharedPCMState’ {aka ‘struct PCMDaemon::SharedPCMState’}; use assignment or value-initialization instead [-Wclass-memaccess]
   std::memset(sharedPCMState_, 0, sizeof(SharedPCMState));
                                                         ^
In file included from ../daemon.h:23,
                 from ../daemon.cpp:30:
../common.h:232:9: note: ‘PCMDaemon::SharedPCMState’ {aka ‘struct PCMDaemon::SharedPCMState’} declared here
  struct SharedPCMState {
         ^~~~~~~~~~~~~~
Finished building: ../daemon.cpp

Signed-off-by: Carlos Santos <casantos@datacom.com.br>