### PR TITLE
Some processors have 8 general purpose counters

### DIFF
--- a/types.h
+++ b/types.h
@@ -50,7 +50,7 @@ typedef signed int int32;
 #define IA32_PERFEVTSEL2_ADDR           (IA32_PERFEVTSEL0_ADDR + 2)
 #define IA32_PERFEVTSEL3_ADDR           (IA32_PERFEVTSEL0_ADDR + 3)
 
-#define PERF_MAX_COUNTERS               (7)
+#define PERF_MAX_COUNTERS               (11)
 
 #define IA32_DEBUGCTL                   (0x1D9)
 


### PR DESCRIPTION
Some processors have 8 general purpose counters and 3 fixed counters, so the total would be 11.
The current code allocates data buffer only for 7 (4 + 3) counters, resulting in a SEGV on these processors.

```
$ cat /proc/cpuinfo | grep 'model name' | uniq
model name	: Intel(R) Xeon(R) CPU E5-1603 v4 @ 2.80GHz

$ sudo ./pcm-core.x 
Number of physical cores: 4
Number of logical cores: 4
Number of online logical cores: 4
Threads (logical cores) per physical core: 1
Num sockets: 1
Physical cores per socket: 4
Core PMU (perfmon) version: 3
Number of core PMU generic (programmable) counters: 8
Width of generic (programmable) counters: 48 bits
Number of core PMU fixed counters: 3
Width of fixed counters: 48 bits
...
```