### PR TITLE
Do not pass garbage values to perf_event_open

### DIFF
--- a/pcm-core.cpp
+++ b/pcm-core.cpp
@@ -63,7 +63,7 @@ extern "C" {
 	SystemCounterState SysBeforeState, SysAfterState;
 	std::vector<CoreCounterState> BeforeState, AfterState;
 	std::vector<SocketCounterState> DummySocketStates;
-	EventSelectRegister regs[4];
+	EventSelectRegister *regs;
 	PCM::ExtendedCustomCoreEventDescription conf;
 
 	int pcm_c_build_core_event(uint8_t idx, const char * argv)
@@ -79,6 +79,7 @@ extern "C" {
 	int pcm_c_init()
 	{
 		PCM * m = PCM::getInstance();
+		regs = (EventSelectRegister*)malloc(sizeof(EventSelectRegister) * m->getMaxCustomCoreEvents());
 		conf.fixedCfg = NULL; // default
 		conf.nGPCounters = m->getMaxCustomCoreEvents();
 		conf.gpCounterCfg = regs;
@@ -290,16 +291,17 @@ int main(int argc, char * argv[])
 	int calibrated = PCM_CALIBRATION_INTERVAL - 2; // keeps track is the clock calibration needed
 	unsigned int numberOfIterations = 0; // number of iterations
 	string program = string(argv[0]);
-	EventSelectRegister regs[4];
+	EventSelectRegister *regs;
 	PCM::ExtendedCustomCoreEventDescription conf;
 	bool show_partial_core_output = false;
 	std::bitset<MAX_CORES> ycores;
 
+        PCM * m = PCM::getInstance();
+
+        regs = (EventSelectRegister*)malloc(sizeof(EventSelectRegister) * m->getMaxCustomCoreEvents());
 	// Occasionally the memory is not properly nulled because counters appear to
 	// be programmed even without given arguments so making really sure
-	memset( &regs, 0, sizeof(regs) );
-
-    PCM * m = PCM::getInstance();
+        memset(regs, 0, sizeof(EventSelectRegister) * m->getMaxCustomCoreEvents());
 
 	conf.fixedCfg = NULL; // default
 	conf.nGPCounters = m->getMaxCustomCoreEvents();

--- a/pcm-core.cpp
+++ b/pcm-core.cpp
@@ -63,7 +63,7 @@ extern "C" {
 	SystemCounterState SysBeforeState, SysAfterState;
 	std::vector<CoreCounterState> BeforeState, AfterState;
 	std::vector<SocketCounterState> DummySocketStates;
-	EventSelectRegister *regs;
+	EventSelectRegister regs[PERF_MAX_COUNTERS];
 	PCM::ExtendedCustomCoreEventDescription conf;
 
 	int pcm_c_build_core_event(uint8_t idx, const char * argv)
@@ -79,7 +79,6 @@ extern "C" {
 	int pcm_c_init()
 	{
 		PCM * m = PCM::getInstance();
-		regs = (EventSelectRegister*)malloc(sizeof(EventSelectRegister) * m->getMaxCustomCoreEvents());
 		conf.fixedCfg = NULL; // default
 		conf.nGPCounters = m->getMaxCustomCoreEvents();
 		conf.gpCounterCfg = regs;
@@ -291,17 +290,12 @@ int main(int argc, char * argv[])
 	int calibrated = PCM_CALIBRATION_INTERVAL - 2; // keeps track is the clock calibration needed
 	unsigned int numberOfIterations = 0; // number of iterations
 	string program = string(argv[0]);
-	EventSelectRegister *regs;
+	EventSelectRegister regs[PERF_MAX_COUNTERS];
 	PCM::ExtendedCustomCoreEventDescription conf;
 	bool show_partial_core_output = false;
 	std::bitset<MAX_CORES> ycores;
 
         PCM * m = PCM::getInstance();
-
-        regs = (EventSelectRegister*)malloc(sizeof(EventSelectRegister) * m->getMaxCustomCoreEvents());
-	// Occasionally the memory is not properly nulled because counters appear to
-	// be programmed even without given arguments so making really sure
-        memset(regs, 0, sizeof(EventSelectRegister) * m->getMaxCustomCoreEvents());
 
 	conf.fixedCfg = NULL; // default
 	conf.nGPCounters = m->getMaxCustomCoreEvents();

--- a/types.h
+++ b/types.h
@@ -50,7 +50,9 @@ typedef signed int int32;
 #define IA32_PERFEVTSEL2_ADDR           (IA32_PERFEVTSEL0_ADDR + 2)
 #define IA32_PERFEVTSEL3_ADDR           (IA32_PERFEVTSEL0_ADDR + 3)
 
-#define PERF_MAX_COUNTERS               (11)
+#define PERF_MAX_FIXED_COUNTERS          (3)
+#define PERF_MAX_CUSTOM_COUNTERS         (8)
+#define PERF_MAX_COUNTERS               (PERF_MAX_FIXED_COUNTERS + PERF_MAX_CUSTOM_COUNTERS)
 
 #define IA32_DEBUGCTL                   (0x1D9)
 
@@ -319,6 +321,8 @@ struct EventSelectRegister
         } fields;
         uint64 value;
     };
+
+    EventSelectRegister() : value(0) {}
 };
 
 


### PR DESCRIPTION
Related to #97.

For processors with 8 general purpose counters, `pcm-core.x` sometimes cannot run due to an error: `"Linux Perf: Error on programming generic event #0 error: Operation not supported"`.

The reason is that `EventSelectRegister regs[4]` has the fixed length of 4, and `m->program(...)` passes non-initialized garbage values to `perf_event_open` when the number of general purpose counters is more than 4 (by accessing `regs[4]`, `regs[5]` and beyond).