### PR TITLE
Revert "daemon.cpp: use C++ assignment to zero-out struct, not memset"

### DIFF
--- a/daemon/daemon/daemon.cpp
+++ b/daemon/daemon/daemon.cpp
@@ -374,7 +374,7 @@ namespace PCMDaemon {
 		}
 
 		//Clear out shared memory
-		*sharedPCMState_ = {};
+		std::memset(sharedPCMState_, 0, sizeof(SharedPCMState));
 	}
 
 	gid_t Daemon::resolveGroupName(const std::string& groupName)


### PR DESCRIPTION
Reverts opcm/pcm#93