### PR TITLE
Fix pmu-query.py for Skylake and Cascade Lake Server

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -2681,9 +2681,9 @@ std::string PCM::getCPUFamilyModelString()
     char buffer[sizeof(int)*4*3+6];
     memset(buffer,0,sizeof(buffer));
 #ifdef _MSC_VER
-    sprintf_s(buffer,sizeof(buffer),"GenuineIntel-%d-%2X",this->cpu_family,this->original_cpu_model);
+    sprintf_s(buffer,sizeof(buffer),"GenuineIntel-%d-%2X-%X",this->cpu_family,this->original_cpu_model,this->cpu_stepping);
 #else
-    snprintf(buffer,sizeof(buffer),"GenuineIntel-%d-%2X",this->cpu_family,this->original_cpu_model);
+    snprintf(buffer,sizeof(buffer),"GenuineIntel-%d-%2X-%X",this->cpu_family,this->original_cpu_model,this->cpu_stepping);
 #endif
     std::string result(buffer);
     return result;

--- a/pmu-query.py
+++ b/pmu-query.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import platform
 import getopt
+import re
 
 all_flag = False
 download_flag = False
@@ -48,7 +49,7 @@ if filename == None:
     (output, err) = p.communicate()
     p_status = p.wait()
     for model in map_file:
-        if model['Family-model'] in output:
+        if re.search(model['Family-model'], output):
             if(model['EventType'] == 'core'):
                 core_path = model['Filename']
             elif(model['EventType'] == 'offcore'):


### PR DESCRIPTION
Skylake and Cascade Lake X both use the same [CPU Model](https://en.wikichip.org/wiki/intel/cpuid#Big_Cores_.28Server.29).
Thats why [mapfile.csv](https://github.com/torvalds/linux/blob/master/tools/perf/pmu-events/arch/x86/mapfile.csv) now also contains regex values for the family model. 

This commit adds the stepping to the CPU Family Model string and uses regex in python to search for occurences. Together both changes fix the pmu-query.py for these processor types.