### PR TITLE
drop (un)-reserve PMU calls

### DIFF
--- a/cpucounters.h
+++ b/cpucounters.h
@@ -753,8 +753,6 @@ private:
 
     std::vector<std::vector<EventSelectRegister> > lastProgrammedCustomCounters;
     uint32 checkCustomCoreProgramming(std::shared_ptr<SafeMsrHandle> msr);
-    void reservePMU();
-    void unreservePMU();
     ErrorCode programCoreCounters(int core, const PCM::ProgramMode mode, const ExtendedCustomCoreEventDescription * pExtDesc,
         std::vector<EventSelectRegister> & programmedCustomCounters);
 


### PR DESCRIPTION
The PERF_STATUS_IN_USE MSR is read-only

Change-Id: Ifd1b2cbf15943ac861cae9988f694a4ee0547cf7