### PR TITLE
Better ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,3 @@ latex/
 *.swp
 .vs/
 .idea/
-cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Release64
 html/
 latex/
 *.swp
+.vs/
+.idea/
+cmake-build-debug/

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ Release64
 html/
 latex/
 *.swp
+*.vcxproj.user
 .vs/
 .idea/


### PR DESCRIPTION
I've been doing some experimentation with PCM and kept nearly committing some IDE generated files (Visual Studio and CLion) on my branches. Adding them to the .gitignore will prevent these accidental commits.