### PR TITLE
Reduce duplicate naming in windows service

### DIFF
--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -36,35 +36,6 @@ namespace PCMServiceNS {
 
     ref class MeasureThread
     {
-    private:
-        String^ CountersCore = gcnew String("PCM Core Counters");
-        String^ CountersSocket = gcnew String("PCM Socket Counters");
-        String^ CountersQpi = gcnew String("PCM QPI Counters");
-
-        String^ MetricCoreClocktick = gcnew String("Clockticks");
-        String^ MetricCoreRetries = gcnew String("Instructions Retired");
-        String^ MetricCoreMissL2 = gcnew String("L2 Cache Misses");
-        String^ MetricCoreMissL3 = gcnew String("L3 Cache Misses");
-        String^ MetircCoreIpc = gcnew String("Instructions Per Clocktick (IPC)");
-        String^ MetricCoreBaseIpc = gcnew String("Base ticks IPC");
-        String^ MetricCoreFreqRel = gcnew String("Relative Frequency (%)");
-        String^ MetricCoreFreqNom = gcnew String("Nominal Frequency");
-        String^ MetricCoreHeadroom = gcnew String("Thermal Headroom below TjMax");
-        String^ MetricCoreResC0 = gcnew String("core C0-state residency (%)");
-        String^ MetricCoreResC3 = gcnew String("core C3-state residency (%)");
-        String^ MetricCoreResC6 = gcnew String("core C6-state residency (%)");
-        String^ MetricCoreResC7 = gcnew String("core C7-state residency (%)");
-
-        String^ MetricSocketBandRead = gcnew String("Memory Read Bandwidth");
-        String^ MetricSocketBandWrite = gcnew String("Memory Write Bandwidth");
-        String^ MetricSocketEnergyPack = gcnew String("Package/Socket Consumed Energy");
-        String^ MetricSocketEnergyDram = gcnew String("DRAM/Memory Consumed Energy");
-        String^ MetricSocketResC2 = gcnew String("package C2-state residency (%)");
-        String^ MetricSocketResC3 = gcnew String("package C3-state residency (%)");
-        String^ MetricSocketResC6 = gcnew String("package C6-state residency (%)");
-        String^ MetricSocketResC7 = gcnew String("package C7-state residency (%)");
-
-        String^ MetricQpiBand = gcnew String("QPI Link Bandwidth");
     public:
         MeasureThread( System::Diagnostics::EventLog^ log ) : log_(log)
         {
@@ -416,6 +387,36 @@ namespace PCMServiceNS {
         System::Diagnostics::EventLog^ log_;
 
         PCM* m_;
+
+        // Counter variable names
+        String^ CountersCore = gcnew String("PCM Core Counters");
+        String^ CountersSocket = gcnew String("PCM Socket Counters");
+        String^ CountersQpi = gcnew String("PCM QPI Counters");
+
+        String^ MetricCoreClocktick = gcnew String("Clockticks");
+        String^ MetricCoreRetries = gcnew String("Instructions Retired");
+        String^ MetricCoreMissL2 = gcnew String("L2 Cache Misses");
+        String^ MetricCoreMissL3 = gcnew String("L3 Cache Misses");
+        String^ MetircCoreIpc = gcnew String("Instructions Per Clocktick (IPC)");
+        String^ MetricCoreBaseIpc = gcnew String("Base ticks IPC");
+        String^ MetricCoreFreqRel = gcnew String("Relative Frequency (%)");
+        String^ MetricCoreFreqNom = gcnew String("Nominal Frequency");
+        String^ MetricCoreHeadroom = gcnew String("Thermal Headroom below TjMax");
+        String^ MetricCoreResC0 = gcnew String("core C0-state residency (%)");
+        String^ MetricCoreResC3 = gcnew String("core C3-state residency (%)");
+        String^ MetricCoreResC6 = gcnew String("core C6-state residency (%)");
+        String^ MetricCoreResC7 = gcnew String("core C7-state residency (%)");
+
+        String^ MetricSocketBandRead = gcnew String("Memory Read Bandwidth");
+        String^ MetricSocketBandWrite = gcnew String("Memory Write Bandwidth");
+        String^ MetricSocketEnergyPack = gcnew String("Package/Socket Consumed Energy");
+        String^ MetricSocketEnergyDram = gcnew String("DRAM/Memory Consumed Energy");
+        String^ MetricSocketResC2 = gcnew String("package C2-state residency (%)");
+        String^ MetricSocketResC3 = gcnew String("package C3-state residency (%)");
+        String^ MetricSocketResC6 = gcnew String("package C6-state residency (%)");
+        String^ MetricSocketResC7 = gcnew String("package C7-state residency (%)");
+
+        String^ MetricQpiBand = gcnew String("QPI Link Bandwidth");
     };
 
     /// <summary>

--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -85,7 +85,7 @@ namespace PCMServiceNS {
             counterCollection->Add( counter );
             counter = gcnew CounterCreationData(MetricCoreMissL3, "Displays the L3 Cache Misses caused by this core.", PerformanceCounterType::CounterDelta64 );
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData(MetircCoreIpc, "Displays the instructions per clocktick executed for this core.", PerformanceCounterType::AverageCount64 );
+            counter = gcnew CounterCreationData(MetricCoreIpc, "Displays the instructions per clocktick executed for this core.", PerformanceCounterType::AverageCount64 );
             counterCollection->Add( counter );
             counter = gcnew CounterCreationData(MetricCoreBaseIpc, "Not visible", PerformanceCounterType::AverageBase );
             counterCollection->Add( counter );
@@ -141,7 +141,7 @@ namespace PCMServiceNS {
                 s = UInt32(i).ToString(); // For core counters we use just the number of the core
                 ticksHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreClocktick, s, false));
                 instRetHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreRetries, s, false));
-                ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetircCoreIpc, s, false));
+                ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreIpc, s, false));
                 baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreBaseIpc, s, false));
                 relFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqRel, s, false));
                 baseTicksForRelFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqNom, s, false));
@@ -161,7 +161,7 @@ namespace PCMServiceNS {
 
                 ticksHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreClocktick, s, false));
                 instRetHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreRetries, s, false));
-                ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetircCoreIpc, s, false));
+                ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreIpc, s, false));
                 baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreBaseIpc, s, false));
                 relFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqRel, s, false));
                 baseTicksForRelFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqNom, s, false));
@@ -196,7 +196,7 @@ namespace PCMServiceNS {
 
             ticksHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreClocktick, s, false));
             instRetHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreRetries, s, false));
-            ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetircCoreIpc, s, false));
+            ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreIpc, s, false));
             baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreBaseIpc, s, false));
             relFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqRel, s, false));
             baseTicksForRelFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqNom, s, false));
@@ -397,7 +397,7 @@ namespace PCMServiceNS {
         initonly String^ MetricCoreRetries = gcnew String("Instructions Retired");
         initonly String^ MetricCoreMissL2 = gcnew String("L2 Cache Misses");
         initonly String^ MetricCoreMissL3 = gcnew String("L3 Cache Misses");
-        initonly String^ MetircCoreIpc = gcnew String("Instructions Per Clocktick (IPC)");
+        initonly String^ MetricCoreIpc = gcnew String("Instructions Per Clocktick (IPC)");
         initonly String^ MetricCoreBaseIpc = gcnew String("Base ticks IPC");
         initonly String^ MetricCoreFreqRel = gcnew String("Relative Frequency (%)");
         initonly String^ MetricCoreFreqNom = gcnew String("Nominal Frequency");

--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -389,34 +389,34 @@ namespace PCMServiceNS {
         PCM* m_;
 
         // Counter variable names
-        String^ CountersCore = gcnew String("PCM Core Counters");
-        String^ CountersSocket = gcnew String("PCM Socket Counters");
-        String^ CountersQpi = gcnew String("PCM QPI Counters");
+        initonly String^ CountersCore = gcnew String("PCM Core Counters");
+        initonly String^ CountersSocket = gcnew String("PCM Socket Counters");
+        initonly String^ CountersQpi = gcnew String("PCM QPI Counters");
 
-        String^ MetricCoreClocktick = gcnew String("Clockticks");
-        String^ MetricCoreRetries = gcnew String("Instructions Retired");
-        String^ MetricCoreMissL2 = gcnew String("L2 Cache Misses");
-        String^ MetricCoreMissL3 = gcnew String("L3 Cache Misses");
-        String^ MetircCoreIpc = gcnew String("Instructions Per Clocktick (IPC)");
-        String^ MetricCoreBaseIpc = gcnew String("Base ticks IPC");
-        String^ MetricCoreFreqRel = gcnew String("Relative Frequency (%)");
-        String^ MetricCoreFreqNom = gcnew String("Nominal Frequency");
-        String^ MetricCoreHeadroom = gcnew String("Thermal Headroom below TjMax");
-        String^ MetricCoreResC0 = gcnew String("core C0-state residency (%)");
-        String^ MetricCoreResC3 = gcnew String("core C3-state residency (%)");
-        String^ MetricCoreResC6 = gcnew String("core C6-state residency (%)");
-        String^ MetricCoreResC7 = gcnew String("core C7-state residency (%)");
+        initonly String^ MetricCoreClocktick = gcnew String("Clockticks");
+        initonly String^ MetricCoreRetries = gcnew String("Instructions Retired");
+        initonly String^ MetricCoreMissL2 = gcnew String("L2 Cache Misses");
+        initonly String^ MetricCoreMissL3 = gcnew String("L3 Cache Misses");
+        initonly String^ MetircCoreIpc = gcnew String("Instructions Per Clocktick (IPC)");
+        initonly String^ MetricCoreBaseIpc = gcnew String("Base ticks IPC");
+        initonly String^ MetricCoreFreqRel = gcnew String("Relative Frequency (%)");
+        initonly String^ MetricCoreFreqNom = gcnew String("Nominal Frequency");
+        initonly String^ MetricCoreHeadroom = gcnew String("Thermal Headroom below TjMax");
+        initonly String^ MetricCoreResC0 = gcnew String("core C0-state residency (%)");
+        initonly String^ MetricCoreResC3 = gcnew String("core C3-state residency (%)");
+        initonly String^ MetricCoreResC6 = gcnew String("core C6-state residency (%)");
+        initonly String^ MetricCoreResC7 = gcnew String("core C7-state residency (%)");
 
-        String^ MetricSocketBandRead = gcnew String("Memory Read Bandwidth");
-        String^ MetricSocketBandWrite = gcnew String("Memory Write Bandwidth");
-        String^ MetricSocketEnergyPack = gcnew String("Package/Socket Consumed Energy");
-        String^ MetricSocketEnergyDram = gcnew String("DRAM/Memory Consumed Energy");
-        String^ MetricSocketResC2 = gcnew String("package C2-state residency (%)");
-        String^ MetricSocketResC3 = gcnew String("package C3-state residency (%)");
-        String^ MetricSocketResC6 = gcnew String("package C6-state residency (%)");
-        String^ MetricSocketResC7 = gcnew String("package C7-state residency (%)");
+        initonly String^ MetricSocketBandRead = gcnew String("Memory Read Bandwidth");
+        initonly String^ MetricSocketBandWrite = gcnew String("Memory Write Bandwidth");
+        initonly String^ MetricSocketEnergyPack = gcnew String("Package/Socket Consumed Energy");
+        initonly String^ MetricSocketEnergyDram = gcnew String("DRAM/Memory Consumed Energy");
+        initonly String^ MetricSocketResC2 = gcnew String("package C2-state residency (%)");
+        initonly String^ MetricSocketResC3 = gcnew String("package C3-state residency (%)");
+        initonly String^ MetricSocketResC6 = gcnew String("package C6-state residency (%)");
+        initonly String^ MetricSocketResC7 = gcnew String("package C7-state residency (%)");
 
-        String^ MetricQpiBand = gcnew String("QPI Link Bandwidth");
+        initonly String^ MetricQpiBand = gcnew String("QPI Link Bandwidth");
     };
 
     /// <summary>

--- a/PCM_Win/windriver.h
+++ b/PCM_Win/windriver.h
@@ -21,6 +21,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include <comdef.h>
 #include "cpucounters.h"
 
+#define MSR_DRIVER_NAME L"PCM Test MSR"
+
 /*!     \file windriver.h
         \brief Loading and unloading custom Windows MSR (Model Specific Register) Driver
 */
@@ -51,12 +53,12 @@ public:
         hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
         if (hSCManager)
         {
-            hService = CreateService(hSCManager, L"PCM Test MSR", L"PCM Test MSR Driver", SERVICE_START | DELETE | SERVICE_STOP,
+            hService = CreateService(hSCManager, MSR_DRIVER_NAME, L"PCM Test MSR Driver", SERVICE_START | DELETE | SERVICE_STOP,
                                      SERVICE_KERNEL_DRIVER, SERVICE_DEMAND_START, SERVICE_ERROR_IGNORE, driverPath, NULL, NULL, NULL, NULL, NULL);
 
             if (!hService)
             {
-                hService = OpenService(hSCManager, L"PCM Test MSR", SERVICE_START | DELETE | SERVICE_STOP);
+                hService = OpenService(hSCManager, MSR_DRIVER_NAME, SERVICE_START | DELETE | SERVICE_STOP);
             }
 
             if (hService)
@@ -99,16 +101,16 @@ public:
         }
 
 
-		std::cerr << "Trying to load winring0.dll/winring0.sys driver..." << std::endl;
-		if(PCM::initWinRing0Lib())
-		{
-			std::cerr << "Using winring0.dll/winring0.sys driver.\n" << std::endl;
-			return true;
-		}
-		else
-		{
-			std::cerr << "Failed to load winring0.dll/winring0.sys driver.\n" << std::endl;
-		}
+        std::cerr << "Trying to load winring0.dll/winring0.sys driver..." << std::endl;
+        if(PCM::initWinRing0Lib())
+        {
+            std::cerr << "Using winring0.dll/winring0.sys driver.\n" << std::endl;
+            return true;
+        }
+        else
+        {
+            std::cerr << "Failed to load winring0.dll/winring0.sys driver.\n" << std::endl;
+        }
 
         return false;
     }
@@ -119,7 +121,7 @@ public:
         hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
         if (hSCManager)
         {
-            hService = OpenService(hSCManager, L"PCM Test MSR", SERVICE_START | DELETE | SERVICE_STOP);
+            hService = OpenService(hSCManager, MSR_DRIVER_NAME, SERVICE_START | DELETE | SERVICE_STOP);
             if (hService)
             {
                 ControlService(hService, SERVICE_CONTROL_STOP, &ss);
@@ -146,7 +148,7 @@ public:
         hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
         if (hSCManager)
         {
-            hService = OpenService(hSCManager, L"PCM Test MSR", SERVICE_START | DELETE | SERVICE_STOP);
+            hService = OpenService(hSCManager, MSR_DRIVER_NAME, SERVICE_START | DELETE | SERVICE_STOP);
             if (hService)
             {
                 ControlService(hService, SERVICE_CONTROL_STOP, &ss);


### PR DESCRIPTION
Moves some commonly used strings into immutable variables so that they are easier to update and extract for use with other tools. It should also make extending the service a bit easier.

Also makes indentation in the affected files consistent to 4 spaces across all lines.