### PR TITLE
Improved microsecond sleep function for Windows

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -30,7 +30,10 @@ CT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 #include <time.h>
 #include "types.h"
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+#include <thr/xthread>
+#include <chrono>
+#else
 #include <csignal>
 #include <ctime>
 #include <cmath>
@@ -52,15 +55,8 @@ void set_post_cleanup_callback(void(*cb)(void));
 #ifdef _MSC_VER
 inline void win_usleep(int delay_us)
 {
-    uint64 t1 = 0, t2 = 0, freq = 0;
-    uint64 wait_tick;
-    QueryPerformanceFrequency((LARGE_INTEGER *)&freq);
-    wait_tick = freq * delay_us / 1000000ULL;
-    QueryPerformanceCounter((LARGE_INTEGER *)&t1);
-    do {
-        QueryPerformanceCounter((LARGE_INTEGER *)&t2);
-        _mm_pause();
-    } while ((t2 - t1) < wait_tick);
+    stdext::threads::xtime _Tgt = _To_xtime(std::chrono::microseconds(delay_us));
+    _Thrd_sleep(&_Tgt);
 }
 #endif
 


### PR DESCRIPTION
Currently, pcm-pcie.exe needs to sleep in microsecond which it does by repeatedly querying the tick counter causing 100% usage of a core to do so. The `thread` library is not available to the service as it must be compiled with the `/clr` flag as it will run as a Windows service. `thr/xthread` and `chrono` can be used, however, to achieve the same result as the thread library where the thread can be suspended for a number of microseconds. This significantly reduces the performance impact of monitoring.

Tested all windows binaries are behaving as expected with change implemented.