### PR TITLE
Reduce duplicate naming in windows service

### DIFF
--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -31,6 +31,10 @@ using namespace System::Threading;
 using namespace System::Runtime::InteropServices;
 
 namespace PCMServiceNS {
+    ref struct Globals
+    {
+        static initonly String^ ServiceName = gcnew String(L"PCMService");
+    };
 
     ref class MeasureThread
     {
@@ -41,32 +45,32 @@ namespace PCMServiceNS {
             m_ = PCM::getInstance();
             if ( !m_->good() )
             {
-                log_->WriteEntry("PCMService", "Monitor Instance could not be created.", EventLogEntryType::Error);
+                log_->WriteEntry(Globals::ServiceName, "Monitor Instance could not be created.", EventLogEntryType::Error);
                 m_->cleanup();
                 String^ s = gcnew String(m_->getErrorMessage().c_str());
                 throw gcnew Exception(s);
             }
-            log_->WriteEntry( "PCMService", "PCM: Number of cores detected: " + UInt32(m_->getNumCores()).ToString() );
+            log_->WriteEntry(Globals::ServiceName, "PCM: Number of cores detected: " + UInt32(m_->getNumCores()).ToString());
 
             m_->program();
 
-            log_->WriteEntry( "PCMService", "PMU Programmed." );
+            log_->WriteEntry(Globals::ServiceName, "PMU Programmed.");
 
             // This here will only create the necessary registry entries, the actual counters are created later.
             // New unified category
-            if ( PerformanceCounterCategory::Exists( "PCM Core Counters" ) )
+            if (PerformanceCounterCategory::Exists(CountersCore))
             {
-                PerformanceCounterCategory::Delete( "PCM Core Counters" );
+                PerformanceCounterCategory::Delete(CountersCore);
             }
-            if ( PerformanceCounterCategory::Exists( "PCM Socket Counters" ) )
+            if (PerformanceCounterCategory::Exists(CountersSocket))
             {
-                PerformanceCounterCategory::Delete( "PCM Socket Counters" );
+                PerformanceCounterCategory::Delete(CountersSocket);
             }
-            if ( PerformanceCounterCategory::Exists( "PCM QPI Counters" ) )
+            if (PerformanceCounterCategory::Exists(CountersQpi))
             {
-                PerformanceCounterCategory::Delete( "PCM QPI Counters" );
+                PerformanceCounterCategory::Delete(CountersQpi);
             }
-            log_->WriteEntry( "PCMService", "Old categories deleted." );
+            log_->WriteEntry(Globals::ServiceName, "Old categories deleted.");
             // First create the collection, then add counters to it so we add them all at once
             CounterCreationDataCollection^ counterCollection = gcnew CounterCreationDataCollection;
 
@@ -75,59 +79,59 @@ namespace PCMServiceNS {
             // CounterCreationData^ counter = gcnew CounterCreationData( "counter", "helptext for counter", PerformanceCounterType::NumberOfItems64 );
             // counterCollection->Add( counter );
             CounterCreationData^ counter;
-            counter = gcnew CounterCreationData( "Clockticks", "Displays the number of clockticks elapsed since previous measurement.", PerformanceCounterType::CounterDelta64 );
+            counter = gcnew CounterCreationData(MetricCoreClocktick, "Displays the number of clockticks elapsed since previous measurement.", PerformanceCounterType::CounterDelta64);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "Instructions Retired", "Displays the number of instructions retired since previous measurement.", PerformanceCounterType::CounterDelta64 );
+            counter = gcnew CounterCreationData(MetricCoreRetired, "Displays the number of instructions retired since previous measurement.", PerformanceCounterType::CounterDelta64);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "L2 Cache Misses", "Displays the L2 Cache Misses caused by this core.", PerformanceCounterType::CounterDelta64 );
+            counter = gcnew CounterCreationData(MetricCoreMissL2, "Displays the L2 Cache Misses caused by this core.", PerformanceCounterType::CounterDelta64);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "L3 Cache Misses", "Displays the L3 Cache Misses caused by this core.", PerformanceCounterType::CounterDelta64 );
+            counter = gcnew CounterCreationData(MetricCoreMissL3, "Displays the L3 Cache Misses caused by this core.", PerformanceCounterType::CounterDelta64);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "Instructions Per Clocktick (IPC)", "Displays the instructions per clocktick executed for this core.", PerformanceCounterType::AverageCount64 );
+            counter = gcnew CounterCreationData(MetricCoreIpc, "Displays the instructions per clocktick executed for this core.", PerformanceCounterType::AverageCount64);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "Base ticks IPC", "Not visible", PerformanceCounterType::AverageBase );
+            counter = gcnew CounterCreationData(MetricCoreBaseIpc, "Not visible", PerformanceCounterType::AverageBase);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "Relative Frequency (%)", "Displays the current frequency of the core to its rated frequency in percent.", PerformanceCounterType::SampleFraction );
+            counter = gcnew CounterCreationData(MetricCoreFreqRel, "Displays the current frequency of the core to its rated frequency in percent.", PerformanceCounterType::SampleFraction);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "Nominal Frequency", "Not visible", PerformanceCounterType::SampleBase );
+            counter = gcnew CounterCreationData(MetricCoreFreqNom, "Not visible", PerformanceCounterType::SampleBase);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "Thermal Headroom below TjMax", "Displays temperature reading in 1 degree Celsius relative to the TjMax temperature. 0 corresponds to the max temperature.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricCoreHeadroom, "Displays temperature reading in 1 degree Celsius relative to the TjMax temperature. 0 corresponds to the max temperature.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "core C0-state residency (%)", "Displays the residency of core or socket in core C0-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricCoreResC0, "Displays the residency of core or socket in core C0-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "core C3-state residency (%)", "Displays the residency of core or socket in core C3-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricCoreResC3, "Displays the residency of core or socket in core C3-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "core C6-state residency (%)", "Displays the residency of core or socket in core C6-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricCoreResC6, "Displays the residency of core or socket in core C6-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "core C7-state residency (%)", "Displays the residency of core or socket in core C7-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricCoreResC7, "Displays the residency of core or socket in core C7-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-            PerformanceCounterCategory::Create( "PCM Core Counters", "Processor Counter Monitor", PerformanceCounterCategoryType::MultiInstance, counterCollection );
+            PerformanceCounterCategory::Create(CountersCore, "Processor Counter Monitor", PerformanceCounterCategoryType::MultiInstance, counterCollection);
 
             counterCollection->Clear();
-            counter = gcnew CounterCreationData( "Memory Read Bandwidth", "Displays the memory read bandwidth in bytes/s of this socket.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketBandRead, "Displays the memory read bandwidth in bytes/s of this socket.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-            counter = gcnew CounterCreationData( "Memory Write Bandwidth", "Displays the memory write bandwidth in bytes/s of this socket.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketBandWrite, "Displays the memory write bandwidth in bytes/s of this socket.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "Package/Socket Consumed Energy", "Displays the energy in Joules consumed by this socket.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketEnergyPack, "Displays the energy in Joules consumed by this socket.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "DRAM/Memory Consumed Energy", "Displays the energy in Joules consumed by DRAM memory attached to the memory controller of this socket.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketEnergyDram, "Displays the energy in Joules consumed by DRAM memory attached to the memory controller of this socket.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "package C2-state residency (%)", "Displays the residency of socket in package C2-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketResC2, "Displays the residency of socket in package C2-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "package C3-state residency (%)", "Displays the residency of socket in package C3-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketResC3, "Displays the residency of socket in package C3-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "package C6-state residency (%)", "Displays the residency of socket in package C6-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketResC6, "Displays the residency of socket in package C6-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-			counter = gcnew CounterCreationData( "package C7-state residency (%)", "Displays the residency of socket in package C7-state in percent.", PerformanceCounterType::NumberOfItems64 );
+            counter = gcnew CounterCreationData(MetricSocketResC7, "Displays the residency of socket in package C7-state in percent.", PerformanceCounterType::NumberOfItems64);
             counterCollection->Add( counter );
-            PerformanceCounterCategory::Create( "PCM Socket Counters", "Processor Counter Monitor", PerformanceCounterCategoryType::MultiInstance, counterCollection );
+            PerformanceCounterCategory::Create(CountersSocket, "Processor Counter Monitor", PerformanceCounterCategoryType::MultiInstance, counterCollection);
 
             counterCollection->Clear();
-            counter = gcnew CounterCreationData( "QPI Link Bandwidth", "Displays the incoming bandwidth in bytes/s of this QPI link.", PerformanceCounterType::CounterDelta64 );
+            counter = gcnew CounterCreationData(MetricQpiBand, "Displays the incoming bandwidth in bytes/s of this QPI link.", PerformanceCounterType::CounterDelta64);
             counterCollection->Add( counter );
-            PerformanceCounterCategory::Create( "PCM QPI Counters", "Processor Counter Monitor", PerformanceCounterCategoryType::MultiInstance, counterCollection );
+            PerformanceCounterCategory::Create(CountersQpi, "Processor Counter Monitor", PerformanceCounterCategoryType::MultiInstance, counterCollection);
 
-            log_->WriteEntry( "PCMService", "New categories added." );
+            log_->WriteEntry(Globals::ServiceName, "New categories added.");
 
             // Registry entries created, now we need to create the programmatic counters. For some things you may want one instance for every core/thread/socket/qpilink so create in a loop.
             // PerformanceCounter^ pc1 = gcnew PerformanceCounter( "SomeCounterName", "nameOfCounterAsEnteredInTheRegistry", "instanceNameOfCounterAsANumber" );
@@ -137,81 +141,85 @@ namespace PCMServiceNS {
             for ( unsigned int i = 0; i < m_->getNumCores(); ++i )
             {
                 s = UInt32(i).ToString(); // For core counters we use just the number of the core
-                ticksHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Clockticks", s, false ) );
-                instRetHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Instructions Retired", s, false ) );
-                ipcHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Instructions Per Clocktick (IPC)", s, false ) );
-                baseTicksForIpcHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Base ticks IPC", s, false ) );
-                relFreqHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Relative Frequency (%)", s, false ) );
-                baseTicksForRelFreqHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Nominal Frequency", s, false ) );
-                l2CacheMissHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "L2 Cache Misses", s, false ) );
-                l3CacheMissHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "L3 Cache Misses", s, false ) );
-				thermalHeadroomHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Thermal Headroom below TjMax", s, false ) );
-				CoreC0StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C0-state residency (%)", s, false ) );
-				CoreC3StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C3-state residency (%)", s, false ) );
-				CoreC6StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C6-state residency (%)", s, false ) );
-				CoreC7StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C7-state residency (%)", s, false ) );
+                ticksHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreClocktick, s, false));
+                instRetHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreRetired, s, false));
+                l2CacheMissHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreMissL2, s, false));
+                l3CacheMissHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreMissL3, s, false));
+                ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreIpc, s, false));
+                baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreBaseIpc, s, false));
+                relFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqRel, s, false));
+                baseTicksForRelFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqNom, s, false));
+                thermalHeadroomHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreHeadroom, s, false));
+                CoreC0StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC0, s, false));
+                CoreC3StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC3, s, false));
+                CoreC6StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC6, s, false));
+                CoreC7StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC7, s, false));
             }
 
             // Create socket instances of the common core counters, names are Socket+number
             for ( unsigned int i=0; i<m_->getNumSockets(); ++i )
             {
                 s = "Socket"+UInt32(i).ToString();
-                ticksHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Clockticks", s, false ) );
-                instRetHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Instructions Retired", s, false ) );
-                ipcHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Instructions Per Clocktick (IPC)", s, false ) );
-                baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Base ticks IPC", s, false ) );
-                relFreqHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Relative Frequency (%)", s, false ) );
-                baseTicksForRelFreqHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Nominal Frequency", s, false ) );
-                l2CacheMissHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "L2 Cache Misses", s, false ) );
-                l3CacheMissHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "L3 Cache Misses", s, false ) );
-				thermalHeadroomHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Thermal Headroom below TjMax", s, false ) );
-				CoreC0StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C0-state residency (%)", s, false ) );
-				CoreC3StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C3-state residency (%)", s, false ) );
-				CoreC6StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C6-state residency (%)", s, false ) );
-				CoreC7StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C7-state residency (%)", s, false ) );
-                mrbHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "Memory Read Bandwidth", s, false ) );
-                mwbHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "Memory Write Bandwidth", s, false ) );
-                qpiHash_.Add( s, gcnew PerformanceCounter( "PCM QPI Counters", "QPI Link Bandwidth", s, false ) ); // Socket aggregate
-				packageEnergyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "Package/Socket Consumed Energy", s, false ) );
-				DRAMEnergyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "DRAM/Memory Consumed Energy", s, false ) );
-				PackageC2StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C2-state residency (%)", s, false ) );
-				PackageC3StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C3-state residency (%)", s, false ) );
-				PackageC6StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C6-state residency (%)", s, false ) );
-				PackageC7StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C7-state residency (%)", s, false ) );
+                ticksHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreClocktick, s, false));
+                instRetHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreRetired, s, false));
+                l2CacheMissHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreMissL2, s, false));
+                l3CacheMissHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreMissL3, s, false));
+                ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreIpc, s, false));
+                baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreBaseIpc, s, false));
+                relFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqRel, s, false));
+                baseTicksForRelFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqNom, s, false));
+                thermalHeadroomHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreHeadroom, s, false));
+                CoreC0StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC0, s, false));
+                CoreC3StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC3, s, false));
+                CoreC6StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC6, s, false));
+                CoreC7StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC7, s, false));
+
+                mrbHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketBandRead, s, false));
+                mwbHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketBandWrite, s, false));
+                packageEnergyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketEnergyPack, s, false));
+                DRAMEnergyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketEnergyDram, s, false));
+                PackageC2StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC2, s, false));
+                PackageC3StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC3, s, false));
+                PackageC6StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC6, s, false));
+                PackageC7StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC7, s, false));
+
+                qpiHash_.Add(s, gcnew PerformanceCounter(CountersQpi, MetricQpiBand, s, false)); // Socket aggregate
                 String^ t;
                 for ( unsigned int j=0; j<m_->getQPILinksPerSocket(); ++j )
                 {
                     t = s + "_Link" + UInt32(j).ToString();
-                    qpiHash_.Add( t, gcnew PerformanceCounter( "PCM QPI Counters", "QPI Link Bandwidth", t, false ) );
+                    qpiHash_.Add(t, gcnew PerformanceCounter(CountersQpi, MetricQpiBand, t, false));
                 }
             }
 
             // Create #system instances of the system specific performance counters, just kidding, there is only one system so 1 instance
             s = "Total_";
-            ticksHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Clockticks", s, false ) );
-            instRetHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Instructions Retired", s, false ) );
-            ipcHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Instructions Per Clocktick (IPC)", s, false ) );
-            baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "Base ticks IPC", s, false ) );
-            relFreqHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Relative Frequency (%)", s, false ) );
-            baseTicksForRelFreqHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Nominal Frequency", s, false ) );
-            l2CacheMissHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "L2 Cache Misses", s, false ) );
-            l3CacheMissHash_.Add(s, gcnew PerformanceCounter( "PCM Core Counters", "L3 Cache Misses", s, false ) );
-			thermalHeadroomHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "Thermal Headroom below TjMax", s, false ) );
-			CoreC0StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C0-state residency (%)", s, false ) );
-			CoreC3StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C3-state residency (%)", s, false ) );
-			CoreC6StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C6-state residency (%)", s, false ) );
-			CoreC7StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Core Counters", "core C7-state residency (%)", s, false ) );
-            mrbHash_.Add(s, gcnew PerformanceCounter( "PCM Socket Counters", "Memory Read Bandwidth", s, false ) );
-            mwbHash_.Add(s, gcnew PerformanceCounter( "PCM Socket Counters", "Memory Write Bandwidth", s, false ) );
-			packageEnergyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "Package/Socket Consumed Energy", s, false ) );
-			DRAMEnergyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "DRAM/Memory Consumed Energy", s, false ) );
-			PackageC2StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C2-state residency (%)", s, false ) );
-			PackageC3StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C3-state residency (%)", s, false ) );
-			PackageC6StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C6-state residency (%)", s, false ) );
-			PackageC7StateResidencyHash_.Add( s, gcnew PerformanceCounter( "PCM Socket Counters", "package C7-state residency (%)", s, false ) );
-            qpiHash_.Add( s, gcnew PerformanceCounter( "PCM QPI Counters", "QPI Link Bandwidth", s, false ) );
+            ticksHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreClocktick, s, false));
+            instRetHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreRetired, s, false));
+            l2CacheMissHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreMissL2, s, false));
+            l3CacheMissHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreMissL3, s, false));
+            ipcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreIpc, s, false));
+            baseTicksForIpcHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreBaseIpc, s, false));
+            relFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqRel, s, false));
+            baseTicksForRelFreqHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreFreqNom, s, false));
+            thermalHeadroomHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreHeadroom, s, false));
+            CoreC0StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC0, s, false));
+            CoreC3StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC3, s, false));
+            CoreC6StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC6, s, false));
+            CoreC7StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersCore, MetricCoreResC7, s, false));
 
-            log_->WriteEntry( "PCMService", "All instances of the performance counter categories have been created." );
+            mrbHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketBandRead, s, false));
+            mwbHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketBandWrite, s, false));
+            packageEnergyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketEnergyPack, s, false));
+            DRAMEnergyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketEnergyDram, s, false));
+            PackageC2StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC2, s, false));
+            PackageC3StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC3, s, false));
+            PackageC6StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC6, s, false));
+            PackageC7StateResidencyHash_.Add(s, gcnew PerformanceCounter(CountersSocket, MetricSocketResC7, s, false));
+
+            qpiHash_.Add(s, gcnew PerformanceCounter(CountersQpi, MetricQpiBand, s, false));
+
+            log_->WriteEntry(Globals::ServiceName, "All instances of the performance counter categories have been created.");
         }
 
         void doMeasurements( void )
@@ -239,30 +247,32 @@ namespace PCMServiceNS {
                     __int64 totalTicks    = getCycles(systemState);
                     __int64 totalRefTicks = m_->getNominalFrequency() * numCores;
                     __int64 totalInstr    = getInstructionsRetired(systemState);
-                    ((PerformanceCounter^)ticksHash_["Total_"])->RawValue = totalTicks;
-                    ((PerformanceCounter^)instRetHash_["Total_"])->RawValue = totalInstr;
-                    ((PerformanceCounter^)ipcHash_["Total_"])->RawValue = totalInstr >> 17;
-                    ((PerformanceCounter^)baseTicksForIpcHash_["Total_"])->RawValue = totalTicks >> 17;
-                    ((PerformanceCounter^)relFreqHash_["Total_"])->RawValue = totalTicks >> 17;
-                    ((PerformanceCounter^)baseTicksForRelFreqHash_["Total_"])->IncrementBy(totalRefTicks >> 17);
-					((PerformanceCounter^)CoreC0StateResidencyHash_["Total_"])->RawValue = __int64(100.*getCoreCStateResidency(0,oldSystemState, systemState));
-					((PerformanceCounter^)CoreC3StateResidencyHash_["Total_"])->RawValue = __int64(100.*getCoreCStateResidency(3,oldSystemState, systemState));
-					((PerformanceCounter^)CoreC6StateResidencyHash_["Total_"])->RawValue = __int64(100.*getCoreCStateResidency(6,oldSystemState, systemState));
-					((PerformanceCounter^)CoreC7StateResidencyHash_["Total_"])->RawValue = __int64(100.*getCoreCStateResidency(7,oldSystemState, systemState));
-					((PerformanceCounter^)PackageC2StateResidencyHash_["Total_"])->RawValue = __int64(100.*getPackageCStateResidency(2,oldSystemState, systemState));
-					((PerformanceCounter^)PackageC3StateResidencyHash_["Total_"])->RawValue = __int64(100.*getPackageCStateResidency(3,oldSystemState, systemState));
-					((PerformanceCounter^)PackageC6StateResidencyHash_["Total_"])->RawValue = __int64(100.*getPackageCStateResidency(6,oldSystemState, systemState));
-					((PerformanceCounter^)PackageC7StateResidencyHash_["Total_"])->RawValue = __int64(100.*getPackageCStateResidency(7,oldSystemState, systemState));
-                    //log_->WriteEntry("PCMService", "Std: " + UInt64(totalTicks).ToString());
-                    //log_->WriteEntry("PCMService", "Ref: " + UInt64(totalRefTicks).ToString());
-                    ((PerformanceCounter^)l2CacheMissHash_["Total_"])->IncrementBy(getL2CacheMisses(oldSystemState, systemState));
-                    ((PerformanceCounter^)l3CacheMissHash_["Total_"])->IncrementBy(getL3CacheMisses(oldSystemState, systemState));
-                    ((PerformanceCounter^)mrbHash_["Total_"])->RawValue = getBytesReadFromMC(oldSystemState, systemState);
-                    ((PerformanceCounter^)mwbHash_["Total_"])->RawValue = getBytesWrittenToMC(oldSystemState, systemState);
-                    ((PerformanceCounter^)qpiHash_["Total_"])->RawValue = getAllIncomingQPILinkBytes(systemState);
-					((PerformanceCounter^)packageEnergyHash_["Total_"])->RawValue = (__int64)getConsumedJoules(oldSystemState, systemState);
-					((PerformanceCounter^)DRAMEnergyHash_["Total_"])->RawValue = (__int64)getDRAMConsumedJoules(oldSystemState, systemState);
-					((PerformanceCounter^)thermalHeadroomHash_["Total_"])->RawValue = systemState.getThermalHeadroom();
+                    ((PerformanceCounter^)ticksHash_[s])->RawValue = totalTicks;
+                    ((PerformanceCounter^)instRetHash_[s])->RawValue = totalInstr;
+                    ((PerformanceCounter^)l2CacheMissHash_[s])->IncrementBy(getL2CacheMisses(oldSystemState, systemState));
+                    ((PerformanceCounter^)l3CacheMissHash_[s])->IncrementBy(getL3CacheMisses(oldSystemState, systemState));
+                    ((PerformanceCounter^)ipcHash_[s])->RawValue = totalInstr >> 17;
+                    ((PerformanceCounter^)baseTicksForIpcHash_[s])->RawValue = totalTicks >> 17;
+                    ((PerformanceCounter^)relFreqHash_[s])->RawValue = totalTicks >> 17;
+                    ((PerformanceCounter^)baseTicksForRelFreqHash_[s])->IncrementBy(totalRefTicks >> 17);
+                    ((PerformanceCounter^)thermalHeadroomHash_[s])->RawValue = systemState.getThermalHeadroom();
+                    ((PerformanceCounter^)CoreC0StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(0,oldSystemState, systemState));
+                    ((PerformanceCounter^)CoreC3StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(3,oldSystemState, systemState));
+                    ((PerformanceCounter^)CoreC6StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(6,oldSystemState, systemState));
+                    ((PerformanceCounter^)CoreC7StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(7,oldSystemState, systemState));
+                    //log_->WriteEntry(Globals::ServiceName, "Std: " + UInt64(totalTicks).ToString());
+                    //log_->WriteEntry(Globals::ServiceName, "Ref: " + UInt64(totalRefTicks).ToString());
+
+                    ((PerformanceCounter^)mrbHash_[s])->RawValue = getBytesReadFromMC(oldSystemState, systemState);
+                    ((PerformanceCounter^)mwbHash_[s])->RawValue = getBytesWrittenToMC(oldSystemState, systemState);
+                    ((PerformanceCounter^)packageEnergyHash_[s])->RawValue = (__int64)getConsumedJoules(oldSystemState, systemState);
+                    ((PerformanceCounter^)DRAMEnergyHash_[s])->RawValue = (__int64)getDRAMConsumedJoules(oldSystemState, systemState);
+                    ((PerformanceCounter^)PackageC2StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(2, oldSystemState, systemState));
+                    ((PerformanceCounter^)PackageC3StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(3, oldSystemState, systemState));
+                    ((PerformanceCounter^)PackageC6StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(6, oldSystemState, systemState));
+                    ((PerformanceCounter^)PackageC7StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(7, oldSystemState, systemState));
+
+                    ((PerformanceCounter^)qpiHash_[s])->RawValue = getAllIncomingQPILinkBytes(systemState);
 
                     // Copy current state to old state
                     oldSystemState = systemState;
@@ -277,26 +287,28 @@ namespace PCMServiceNS {
                         __int64 socketInstr    = getInstructionsRetired(socketState);
                         ((PerformanceCounter^)instRetHash_[s])->RawValue = socketInstr;
                         ((PerformanceCounter^)ipcHash_[s])->RawValue = socketInstr >> 17;
+                        ((PerformanceCounter^)l2CacheMissHash_[s])->IncrementBy(getL2CacheMisses(oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)l3CacheMissHash_[s])->IncrementBy(getL3CacheMisses(oldSocketStates[i], socketState));
                         ((PerformanceCounter^)ticksHash_[s])->RawValue = socketTicks;
                         ((PerformanceCounter^)baseTicksForIpcHash_[s])->RawValue = socketTicks >> 17;
                         ((PerformanceCounter^)relFreqHash_[s])->RawValue = socketTicks >> 17;
                         ((PerformanceCounter^)baseTicksForRelFreqHash_[s])->IncrementBy(socketRefTicks >> 17);
-                        ((PerformanceCounter^)l2CacheMissHash_[s])->IncrementBy(getL2CacheMisses(oldSocketStates[i], socketState));
-                        ((PerformanceCounter^)l3CacheMissHash_[s])->IncrementBy(getL3CacheMisses(oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)thermalHeadroomHash_[s])->RawValue = socketState.getThermalHeadroom();
+                        ((PerformanceCounter^)CoreC0StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(0, oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)CoreC3StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(3, oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)CoreC6StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(6, oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)CoreC7StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(7, oldSocketStates[i], socketState));
+
                         ((PerformanceCounter^)mrbHash_[s])->RawValue = getBytesReadFromMC(oldSocketStates[i], socketState);
                         ((PerformanceCounter^)mwbHash_[s])->RawValue = getBytesWrittenToMC(oldSocketStates[i], socketState);
+                        ((PerformanceCounter^)packageEnergyHash_[s])->RawValue = (__int64)getConsumedJoules(oldSocketStates[i], socketState);
+                        ((PerformanceCounter^)DRAMEnergyHash_[s])->RawValue = (__int64)getDRAMConsumedJoules(oldSocketStates[i], socketState);
+                        ((PerformanceCounter^)PackageC2StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(2,oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)PackageC3StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(3,oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)PackageC6StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(6,oldSocketStates[i], socketState));
+                        ((PerformanceCounter^)PackageC7StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(7,oldSocketStates[i], socketState));
+
                         ((PerformanceCounter^)qpiHash_[s])->RawValue = getSocketIncomingQPILinkBytes(i, systemState);
-						((PerformanceCounter^)packageEnergyHash_[s])->RawValue = (__int64)getConsumedJoules(oldSocketStates[i], socketState);
-						((PerformanceCounter^)DRAMEnergyHash_[s])->RawValue = (__int64)getDRAMConsumedJoules(oldSocketStates[i], socketState);
-						((PerformanceCounter^)thermalHeadroomHash_[s])->RawValue = socketState.getThermalHeadroom();
-						((PerformanceCounter^)CoreC0StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(0,oldSocketStates[i], socketState));
-						((PerformanceCounter^)CoreC3StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(3,oldSocketStates[i], socketState));
-						((PerformanceCounter^)CoreC6StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(6,oldSocketStates[i], socketState));
-						((PerformanceCounter^)CoreC7StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(7,oldSocketStates[i], socketState));
-						((PerformanceCounter^)PackageC2StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(2,oldSocketStates[i], socketState));
-						((PerformanceCounter^)PackageC3StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(3,oldSocketStates[i], socketState));
-						((PerformanceCounter^)PackageC6StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(6,oldSocketStates[i], socketState));
-						((PerformanceCounter^)PackageC7StateResidencyHash_[s])->RawValue = __int64(100.*getPackageCStateResidency(7,oldSocketStates[i], socketState));
                         String^ t;
                         // and qpi link counters per socket
                         for ( unsigned int j=0; j<numQpiLinks; ++j )
@@ -317,17 +329,17 @@ namespace PCMServiceNS {
                         __int64 instr    = getInstructionsRetired(coreState);
                         ((PerformanceCounter^)instRetHash_[s])->RawValue = instr;
                         ((PerformanceCounter^)ipcHash_[s])->RawValue = instr >> 17;
+                        ((PerformanceCounter^)l2CacheMissHash_[s])->IncrementBy(getL2CacheMisses(oldCoreStates[i], coreState));
+                        ((PerformanceCounter^)l3CacheMissHash_[s])->IncrementBy(getL3CacheMisses(oldCoreStates[i], coreState));
                         ((PerformanceCounter^)ticksHash_[s])->RawValue = ticks;
                         ((PerformanceCounter^)baseTicksForIpcHash_[s])->RawValue = ticks >> 17;
                         ((PerformanceCounter^)relFreqHash_[s])->RawValue = ticks >> 17;
                         ((PerformanceCounter^)baseTicksForRelFreqHash_[s])->IncrementBy(refTicks >> 17);
-                        ((PerformanceCounter^)l2CacheMissHash_[s])->IncrementBy(getL2CacheMisses(oldCoreStates[i], coreState));
-                        ((PerformanceCounter^)l3CacheMissHash_[s])->IncrementBy(getL3CacheMisses(oldCoreStates[i], coreState));
-						((PerformanceCounter^)thermalHeadroomHash_[s])->RawValue = coreState.getThermalHeadroom();
-						((PerformanceCounter^)CoreC0StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(0,oldCoreStates[i], coreState));
-						((PerformanceCounter^)CoreC3StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(3,oldCoreStates[i], coreState));
-						((PerformanceCounter^)CoreC6StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(6,oldCoreStates[i], coreState));
-						((PerformanceCounter^)CoreC7StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(7,oldCoreStates[i], coreState));
+                        ((PerformanceCounter^)thermalHeadroomHash_[s])->RawValue = coreState.getThermalHeadroom();
+                        ((PerformanceCounter^)CoreC0StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(0,oldCoreStates[i], coreState));
+                        ((PerformanceCounter^)CoreC3StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(3,oldCoreStates[i], coreState));
+                        ((PerformanceCounter^)CoreC6StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(6,oldCoreStates[i], coreState));
+                        ((PerformanceCounter^)CoreC7StateResidencyHash_[s])->RawValue = __int64(100.*getCoreCStateResidency(7,oldCoreStates[i], coreState));
                         oldCoreStates[i] = coreState;
                     }
                 }
@@ -342,8 +354,8 @@ namespace PCMServiceNS {
             // Here we now have the chance to do cleanup after catching the ThreadAbortException because of the ResetAbort
             m_->cleanup();
 
-			delete[] oldSocketStates;
-			delete[] oldCoreStates;
+            delete[] oldSocketStates;
+            delete[] oldCoreStates;
         }
 
     private:
@@ -361,37 +373,67 @@ namespace PCMServiceNS {
         System::Collections::Hashtable mwbHash_;
         // QPI counter hashtables
         System::Collections::Hashtable qpiHash_;
-		// Energy counters
-		System::Collections::Hashtable packageEnergyHash_;
-		System::Collections::Hashtable DRAMEnergyHash_;
-		// Thermal headroom
-		System::Collections::Hashtable thermalHeadroomHash_;
-		// C-state Residencies
-		System::Collections::Hashtable CoreC0StateResidencyHash_;		
-		System::Collections::Hashtable CoreC3StateResidencyHash_;
-		System::Collections::Hashtable CoreC6StateResidencyHash_;
-		System::Collections::Hashtable CoreC7StateResidencyHash_;
-		System::Collections::Hashtable PackageC2StateResidencyHash_;
-		System::Collections::Hashtable PackageC3StateResidencyHash_;
-		System::Collections::Hashtable PackageC6StateResidencyHash_;
-		System::Collections::Hashtable PackageC7StateResidencyHash_;
+        // Energy counters
+        System::Collections::Hashtable packageEnergyHash_;
+        System::Collections::Hashtable DRAMEnergyHash_;
+        // Thermal headroom
+        System::Collections::Hashtable thermalHeadroomHash_;
+        // C-state Residencies
+        System::Collections::Hashtable CoreC0StateResidencyHash_;		
+        System::Collections::Hashtable CoreC3StateResidencyHash_;
+        System::Collections::Hashtable CoreC6StateResidencyHash_;
+        System::Collections::Hashtable CoreC7StateResidencyHash_;
+        System::Collections::Hashtable PackageC2StateResidencyHash_;
+        System::Collections::Hashtable PackageC3StateResidencyHash_;
+        System::Collections::Hashtable PackageC6StateResidencyHash_;
+        System::Collections::Hashtable PackageC7StateResidencyHash_;
 
         System::Diagnostics::EventLog^ log_;
 
         PCM* m_;
+
+        // Counter variable names
+        initonly String^ CountersCore = gcnew String(L"PCM Core Counters");
+        initonly String^ CountersSocket = gcnew String(L"PCM Socket Counters");
+        initonly String^ CountersQpi = gcnew String(L"PCM QPI Counters");
+
+        initonly String^ MetricCoreClocktick = gcnew String(L"Clockticks");
+        initonly String^ MetricCoreRetired = gcnew String(L"Instructions Retired");
+        initonly String^ MetricCoreMissL2 = gcnew String(L"L2 Cache Misses");
+        initonly String^ MetricCoreMissL3 = gcnew String(L"L3 Cache Misses");
+        initonly String^ MetricCoreIpc = gcnew String(L"Instructions Per Clocktick (IPC)");
+        initonly String^ MetricCoreBaseIpc = gcnew String(L"Base ticks IPC");
+        initonly String^ MetricCoreFreqRel = gcnew String(L"Relative Frequency (%)");
+        initonly String^ MetricCoreFreqNom = gcnew String(L"Nominal Frequency");
+        initonly String^ MetricCoreHeadroom = gcnew String(L"Thermal Headroom below TjMax");
+        initonly String^ MetricCoreResC0 = gcnew String(L"core C0-state residency (%)");
+        initonly String^ MetricCoreResC3 = gcnew String(L"core C3-state residency (%)");
+        initonly String^ MetricCoreResC6 = gcnew String(L"core C6-state residency (%)");
+        initonly String^ MetricCoreResC7 = gcnew String(L"core C7-state residency (%)");
+
+        initonly String^ MetricSocketBandRead = gcnew String(L"Memory Read Bandwidth");
+        initonly String^ MetricSocketBandWrite = gcnew String(L"Memory Write Bandwidth");
+        initonly String^ MetricSocketEnergyPack = gcnew String(L"Package/Socket Consumed Energy");
+        initonly String^ MetricSocketEnergyDram = gcnew String(L"DRAM/Memory Consumed Energy");
+        initonly String^ MetricSocketResC2 = gcnew String(L"package C2-state residency (%)");
+        initonly String^ MetricSocketResC3 = gcnew String(L"package C3-state residency (%)");
+        initonly String^ MetricSocketResC6 = gcnew String(L"package C6-state residency (%)");
+        initonly String^ MetricSocketResC7 = gcnew String(L"package C7-state residency (%)");
+
+        initonly String^ MetricQpiBand = gcnew String(L"QPI Link Bandwidth");
     };
 
-	/// <summary>
-	/// Summary for PMCService
-	/// </summary>
-	///
-	/// WARNING: If you change the name of this class, you will need to change the
-	///          'Resource File Name' property for the managed resource compiler tool
-	///          associated with all .resx files this class depends on.  Otherwise,
-	///          the designers will not be able to interact properly with localized
-	///          resources associated with this form.
-	public ref class PCMService : public System::ServiceProcess::ServiceBase
-	{
+    /// <summary>
+    /// Summary for PMCService
+    /// </summary>
+    ///
+    /// WARNING: If you change the name of this class, you will need to change the
+    ///          'Resource File Name' property for the managed resource compiler tool
+    ///          associated with all .resx files this class depends on.  Otherwise,
+    ///          the designers will not be able to interact properly with localized
+    ///          resources associated with this form.
+    public ref class PCMService : public System::ServiceProcess::ServiceBase
+    {
     [DllImport ("advapi32.dll")]
     static bool SetServiceStatus (IntPtr hServiceStatus, LPSERVICE_STATUS lpServiceStatus);
 
@@ -415,36 +457,36 @@ namespace PCMServiceNS {
         }
 
 
-	public:
-		PCMService()
-		{
-			InitializeComponent();
-			//
-			//TODO: Add the constructor code here
-			//
-		}
-	protected:
-		/// <summary>
-		/// Clean up any resources being used.
-		/// </summary>
-		~PCMService()
-		{
-			if (components)
-			{
-				delete components;
-			}
-		}
+    public:
+        PCMService()
+        {
+            InitializeComponent();
+            //
+            //TODO: Add the constructor code here
+            //
+        }
+    protected:
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        ~PCMService()
+        {
+            if (components)
+            {
+                delete components;
+            }
+        }
 
-		/// <summary>
-		/// Set things in motion so your service can do its work.
-		/// </summary>
-		virtual void OnStart(array<String^>^ args) override
-		{
+        /// <summary>
+        /// Set things in motion so your service can do its work.
+        /// </summary>
+        virtual void OnStart(array<String^>^ args) override
+        {
             this->RequestAdditionalTime(4000);
             // We should open the driver here
             TCHAR driverPath[] = L"c:\\windows\\system32\\msr.sys";
 
-            EventLog->WriteEntry("PCMService", "Trying to start the driver...", EventLogEntryType::Information);
+            EventLog->WriteEntry(Globals::ServiceName, "Trying to start the driver...", EventLogEntryType::Information);
             drv_ = new Driver;
             try
             {
@@ -452,7 +494,7 @@ namespace PCMServiceNS {
             }
             catch (std::runtime_error* e)
             {
-                String^ s = gcnew String("Cannot open the driver msr.sys.\nYou must have a signed msr.sys driver in c:\\windows\\system32\\ and have administrator rights to run this program.\n\n");
+                String^ s = gcnew String(L"Cannot open the driver msr.sys.\nYou must have a signed msr.sys driver in c:\\windows\\system32\\ and have administrator rights to run this program.\n\n");
                 String^ es = gcnew String(e->what());
                 
                 throw gcnew Exception(s + es);
@@ -460,14 +502,14 @@ namespace PCMServiceNS {
 
             // TODO: Add code here to start your service.
             MeasureThread^ mt;
-            EventLog->WriteEntry("PCMService", "Trying to create the measure thread...", EventLogEntryType::Information);
+            EventLog->WriteEntry(Globals::ServiceName, "Trying to create the measure thread...", EventLogEntryType::Information);
             try
             {
                 mt = gcnew MeasureThread(EventLog);
             }
             catch (Exception^ e)
             {
-                EventLog->WriteEntry("PCMService", e->Message, EventLogEntryType::Error);
+                EventLog->WriteEntry(Globals::ServiceName, e->Message, EventLogEntryType::Error);
                 SetServiceFail(0x80886);
                 throw e;
             }
@@ -478,43 +520,43 @@ namespace PCMServiceNS {
             workerThread_->Start();
 //            EventLog->WriteEntry("PCMService", System::DateTime::Now.ToLongTimeString() + " Monitor could not initialize PMU, aborting.", EventLogEntryType::Error);
 
-		}
+        }
 
-		/// <summary>
-		/// Stop this service.
-		/// </summary>
-		virtual void OnStop() override
-		{
+        /// <summary>
+        /// Stop this service.
+        /// </summary>
+        virtual void OnStop() override
+        {
             // TODO: Add code here to perform any tear-down necessary to stop your service.
             this->RequestAdditionalTime(4000);
             // Stop timer/thread
             // doMeasurements will do cleanup itself, might have to do some sanity checks here
             workerThread_->Abort();
             drv_->stop();
-		}
+        }
 
-	private:
-		/// <summary>
-		/// Required designer variable.
-		/// </summary>
-		System::ComponentModel::Container ^components;
+    private:
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        System::ComponentModel::Container ^components;
         System::Threading::Thread^ workerThread_;
         Driver* drv_;
 
 #pragma region Windows Form Designer generated code
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		void InitializeComponent(void)
-		{
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        void InitializeComponent(void)
+        {
             // 
             // PCMService
             // 
             this->CanPauseAndContinue = true;
-            this->ServiceName = L"PCMService";
+            this->ServiceName = Globals::ServiceName;
 
         }
 #pragma endregion
-	};
+    };
 }

--- a/PCM_Win/windriver.h
+++ b/PCM_Win/windriver.h
@@ -51,12 +51,12 @@ public:
         hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
         if (hSCManager)
         {
-            hService = CreateService(hSCManager, L"PCM Test MSR", L"PCM Test MSR Driver", SERVICE_START | DELETE | SERVICE_STOP,
+            hService = CreateService(hSCManager, DriverName, L"PCM Test MSR Driver", SERVICE_START | DELETE | SERVICE_STOP,
                                      SERVICE_KERNEL_DRIVER, SERVICE_DEMAND_START, SERVICE_ERROR_IGNORE, driverPath, NULL, NULL, NULL, NULL, NULL);
 
             if (!hService)
             {
-                hService = OpenService(hSCManager, L"PCM Test MSR", SERVICE_START | DELETE | SERVICE_STOP);
+                hService = OpenService(hSCManager, DriverName, SERVICE_START | DELETE | SERVICE_STOP);
             }
 
             if (hService)
@@ -99,16 +99,16 @@ public:
         }
 
 
-		std::cerr << "Trying to load winring0.dll/winring0.sys driver..." << std::endl;
-		if(PCM::initWinRing0Lib())
-		{
-			std::cerr << "Using winring0.dll/winring0.sys driver.\n" << std::endl;
-			return true;
-		}
-		else
-		{
-			std::cerr << "Failed to load winring0.dll/winring0.sys driver.\n" << std::endl;
-		}
+        std::cerr << "Trying to load winring0.dll/winring0.sys driver..." << std::endl;
+        if(PCM::initWinRing0Lib())
+        {
+            std::cerr << "Using winring0.dll/winring0.sys driver.\n" << std::endl;
+            return true;
+        }
+        else
+        {
+            std::cerr << "Failed to load winring0.dll/winring0.sys driver.\n" << std::endl;
+        }
 
         return false;
     }
@@ -119,7 +119,7 @@ public:
         hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
         if (hSCManager)
         {
-            hService = OpenService(hSCManager, L"PCM Test MSR", SERVICE_START | DELETE | SERVICE_STOP);
+            hService = OpenService(hSCManager, DriverName, SERVICE_START | DELETE | SERVICE_STOP);
             if (hService)
             {
                 ControlService(hService, SERVICE_CONTROL_STOP, &ss);
@@ -146,7 +146,7 @@ public:
         hSCManager = OpenSCManager(NULL, NULL, SC_MANAGER_CREATE_SERVICE);
         if (hSCManager)
         {
-            hService = OpenService(hSCManager, L"PCM Test MSR", SERVICE_START | DELETE | SERVICE_STOP);
+            hService = OpenService(hSCManager, DriverName, SERVICE_START | DELETE | SERVICE_STOP);
             if (hService)
             {
                 ControlService(hService, SERVICE_CONTROL_STOP, &ss);
@@ -164,6 +164,9 @@ public:
             std::wcerr << std::endl;
         }
     }
+
+private:
+    const LPCWSTR DriverName = L"PCM Test MSR";
 };
 
 #endif


### PR DESCRIPTION
_Rework of #132 to reduce the amount commit history to only contain a final version of changes_

Moves some commonly used strings into immutable variables so that they are easier to update and extract for use with other tools. It should also make extending the service a bit easier.

Also makes indentation in the affected files consistent to 4 spaces across all lines.