### PR TITLE
Allow Windows application to be built without WinRing0 driver loading ability

### DIFF
--- a/PCM_Win/windriver.h
+++ b/PCM_Win/windriver.h
@@ -98,7 +98,7 @@ public:
             std::wcerr << std::endl;
         }
 
-
+        #ifndef NO_WINRING
         std::cerr << "Trying to load winring0.dll/winring0.sys driver..." << std::endl;
         if(PCM::initWinRing0Lib())
         {
@@ -109,6 +109,7 @@ public:
         {
             std::cerr << "Failed to load winring0.dll/winring0.sys driver.\n" << std::endl;
         }
+        #endif // NO_WINRING
 
         return false;
     }

--- a/PCM_Win/windriver.h
+++ b/PCM_Win/windriver.h
@@ -98,7 +98,7 @@ public:
             std::wcerr << std::endl;
         }
 
-        #ifndef NO_WINRING
+        #ifndef NO_WINRING // In cases where loading the WinRing0 driver is not desirable as a fallback to MSR.sys, add -DNO_WINRING to compile command to remove ability to load driver (will also remove initWinRing0Lib function)
         std::cerr << "Trying to load winring0.dll/winring0.sys driver..." << std::endl;
         if(PCM::initWinRing0Lib())
         {

--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -104,6 +104,7 @@ int convertUnknownToInt(size_t size, char* value);
 
 HMODULE hOpenLibSys = NULL;
 
+#ifndef NO_WINRING
 bool PCM::initWinRing0Lib()
 {
     const BOOL result = InitOpenLibSys(&hOpenLibSys);
@@ -122,6 +123,7 @@ bool PCM::initWinRing0Lib()
 
     return true;
 }
+#endif // NO_WINRING
 
 class InstanceLock
 {

--- a/cpucounters.h
+++ b/cpucounters.h
@@ -1373,7 +1373,7 @@ public:
     //! \brief Returns maximum power derived from electrical spec of the package domain in Watt
     int32 getPackageMaximumPower() const { return pkgMaximumPower; }
 
-    #ifndef NO_WINRING
+    #ifndef NO_WINRING // In cases where loading the WinRing0 driver is not desirable as a fallback to MSR.sys, add -DNO_WINRING to compile command to remove ability to load driver
     //! \brief Loads and initializes Winring0 third party library for access to processor model specific and PCI configuration registers
     //! \return returns true in case of success
     static bool initWinRing0Lib();

--- a/cpucounters.h
+++ b/cpucounters.h
@@ -1373,9 +1373,11 @@ public:
     //! \brief Returns maximum power derived from electrical spec of the package domain in Watt
     int32 getPackageMaximumPower() const { return pkgMaximumPower; }
 
+    #ifndef NO_WINRING
     //! \brief Loads and initializes Winring0 third party library for access to processor model specific and PCI configuration registers
     //! \return returns true in case of success
     static bool initWinRing0Lib();
+    #endif // NO_WINRING
 
     inline void disableJKTWorkaround() { disable_JKT_workaround = true; }
 


### PR DESCRIPTION
Due to the wide range of functionality included within the WinRing0 driver beyond PCMs requirements, compiling out the ability of the application to try and load the driver would allow a sightly securer build of the application. This is achieved by adding the NO_WINRING preprocessor definition which can be added as required to build steps.

For most use cases, using WinRing0 poses no issue so I do not propose this become the default way of building the applications.