### PR TITLE
Fix pcm-tsx-win BSOD

### DIFF
--- a/cpucounters.h
+++ b/cpucounters.h
@@ -1659,6 +1659,20 @@ public:
                ;
     }
 
+    bool supportsInTx() const
+    {
+        return    PCM::HASWELL == cpu_model
+               || PCM::HASWELLX == cpu_model
+               || PCM::BROADWELL == cpu_model
+               || PCM::BROADWELL_XEON_E3 == cpu_model
+               || PCM::BDX_DE == cpu_model
+               || PCM::BDX == cpu_model
+               || PCM::KBL == cpu_model
+               || PCM::SKL == cpu_model
+               || PCM::SKX == cpu_model
+               ;
+    }
+
     static double getBytesPerFlit(int32 cpu_model_)
     {
         if(cpu_model_ == PCM::SKX)

--- a/pcm-tsx.cpp
+++ b/pcm-tsx.cpp
@@ -323,13 +323,22 @@ int main(int argc, char * argv[])
         }
         regs[N_RTM_POS].fields.event_select = 0xc9;
         regs[N_RTM_POS].fields.umask = 0x01;
+
         regs[N_HLE_POS].fields.event_select = 0xc8;
         regs[N_HLE_POS].fields.umask = 0x01;
+
         regs[TX_CYCLES_COMMITED_POS].fields.event_select = 0x3c;
-        regs[TX_CYCLES_COMMITED_POS].fields.in_tx = 1;
-        regs[TX_CYCLES_COMMITED_POS].fields.in_txcp = 1;
+        if (m->supportsInTx())
+        {
+            regs[TX_CYCLES_COMMITED_POS].fields.in_tx = 1;
+            regs[TX_CYCLES_COMMITED_POS].fields.in_txcp = 1;
+        }
+
         regs[TX_CYCLES_POS].fields.event_select = 0x3c;
-        regs[TX_CYCLES_POS].fields.in_tx = 1;
+        if (m->supportsInTx())
+        {
+            regs[TX_CYCLES_POS].fields.in_tx = 1;
+        }
     }
     else
     {


### PR DESCRIPTION
Testing pcm-tsx with a Jaketown processor caused the machine to blue screen due to memory corruption. Crash dump analysis determined this was whilst writing to MSR 0x187 (IA32_PERFEVTSEL1). On earlier architectures bit 32 is part of the reserved range whilst in Haswell and later it is the IN_TX value. pcm-tsx wrote to that bit on all architectures. Only setting that bit when it is on a supported architecture ensures that running the tool on an older architecture does not have an adverse impact.

This has been implemented as a white list of architectures as the "Intel 64 and IA-32 Software Developer's Manual: Volume 4" does not offer an explicit flag for that register but instead describes the architectures on which it applies.