### PR TITLE
Allow driver loading to be configured via registry on Windows

### DIFF
--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -484,20 +484,14 @@ namespace PCMServiceNS {
         {
             this->RequestAdditionalTime(4000);
             // We should open the driver here
-            TCHAR driverPath[] = L"c:\\windows\\system32\\msr.sys";
-
             EventLog->WriteEntry(Globals::ServiceName, "Trying to start the driver...", EventLogEntryType::Information);
             drv_ = new Driver;
-            try
+            if (!drv_->start())
             {
-                drv_->start(driverPath);
-            }
-            catch (std::runtime_error* e)
-            {
-                String^ s = gcnew String(L"Cannot open the driver msr.sys.\nYou must have a signed msr.sys driver in c:\\windows\\system32\\ and have administrator rights to run this program.\n\n");
-                String^ es = gcnew String(e->what());
-                
-                throw gcnew Exception(s + es);
+                String^ s = gcnew String((L"Cannot open the driver.\nYou must have a signed driver at " + drv_->DriverPath() + L" and have administrator rights to run this program.\n\n").c_str());
+                EventLog->WriteEntry(Globals::ServiceName, s, EventLogEntryType::Error);
+                SetServiceFail(ERROR_FILE_NOT_FOUND);
+                throw gcnew Exception(s);
             }
 
             // TODO: Add code here to start your service.

--- a/PCM-Service_Win/PCMService.h
+++ b/PCM-Service_Win/PCMService.h
@@ -488,7 +488,7 @@ namespace PCMServiceNS {
             drv_ = new Driver;
             if (!drv_->start())
             {
-                String^ s = gcnew String((L"Cannot open the driver.\nYou must have a signed driver at " + drv_->DriverPath() + L" and have administrator rights to run this program.\n\n").c_str());
+                String^ s = gcnew String((L"Cannot open the driver.\nYou must have a signed driver at " + drv_->driverPath() + L" and have administrator rights to run this program.\n\n").c_str());
                 EventLog->WriteEntry(Globals::ServiceName, s, EventLogEntryType::Error);
                 SetServiceFail(ERROR_FILE_NOT_FOUND);
                 throw gcnew Exception(s);

--- a/PCM_Win/windriver.h
+++ b/PCM_Win/windriver.h
@@ -55,7 +55,7 @@ public:
             gcdReturn = GetCurrentDirectory(driverPathLen, &driverPath[0]);
         } while (0 != gcdReturn && driverPathLen < gcdReturn);
 
-        RemoveNullTerminator(driverPath);
+        removeNullTerminator(driverPath);
 
         return driverPath + L"\\msr.sys";
     }
@@ -71,13 +71,13 @@ public:
     }
 
     Driver(const std::wstring& driverPath, const std::wstring& driverName, const std::wstring& driverDescription) :
-        driverPath_(SetConfigValue(L"DriverPath", driverPath)),
-        driverName_(SetConfigValue(L"DriverName", driverName)),
-        driverDescription_(SetConfigValue(L"DriverDescription", driverDescription))
+        driverPath_(setConfigValue(L"DriverPath", driverPath)),
+        driverName_(setConfigValue(L"DriverName", driverName)),
+        driverDescription_(setConfigValue(L"DriverDescription", driverDescription))
     {
     }
 
-    const std::wstring& DriverPath() const
+    const std::wstring& driverPath() const
     {
         return driverPath_;
     }
@@ -213,7 +213,7 @@ public:
 
 private:
 
-    std::wstring SetConfigValue(const LPCWSTR key, const std::wstring& defaultValue)
+    static std::wstring setConfigValue(const LPCWSTR key, const std::wstring& defaultValue)
     {
         static_assert(std::is_same<WCHAR, wchar_t>::value, "WCHAR expected to be wchar_t");
 
@@ -221,23 +221,23 @@ private:
         DWORD regLen = 1 * sizeof(WCHAR);
         DWORD regRes = ERROR_FILE_NOT_FOUND; // Safe error to start with in case key doesn't exist
 
-        HKEY hkey;
-        if (ERROR_SUCCESS == RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\pcm", NULL, KEY_READ, &hkey))
+        HKEY hKey;
+        if (ERROR_SUCCESS == RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\pcm", NULL, KEY_READ, &hKey))
         {
             do {
                 regRead.resize(regLen / sizeof(WCHAR));
-                regRes = RegQueryValueEx(hkey, key, NULL, NULL, (LPBYTE)&regRead[0], &regLen);
+                regRes = RegQueryValueEx(hKey, key, NULL, NULL, (LPBYTE)&regRead[0], &regLen);
             } while (ERROR_MORE_DATA == regRes);
 
-            RegCloseKey(hkey);
+            RegCloseKey(hKey);
         }
 
-        RemoveNullTerminator(regRead);
+        removeNullTerminator(regRead);
             
         return ERROR_SUCCESS == regRes ? regRead : defaultValue;
     }
 
-    static void RemoveNullTerminator(std::wstring& s)
+    static void removeNullTerminator(std::wstring& s)
     {
         if (!s.empty() && s.back() == '\0')
         {

--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -1719,16 +1719,13 @@ PCM::PCM() :
     needToRestoreNMIWatchdog(false)
 {
 #ifdef _MSC_VER
-    TCHAR driverPath[1040]; // length for current directory + "\\msr.sys"
-    GetCurrentDirectory(1024, driverPath);
-    wcscat_s(driverPath, 1040, L"\\msr.sys");
     // WARNING: This driver code (msr.sys) is only for testing purposes, not for production use
-    Driver drv;
+    Driver drv(Driver::msrLocalPath());
     // drv.stop();     // restart driver (usually not needed)
-    if (!drv.start(driverPath))
+    if (!drv.start())
     {
-        std::cerr << "Cannot access CPU counters" << std::endl;
-        std::cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
+        std::wcerr << "Cannot access CPU counters" << std::endl;
+        std::wcerr << "You must have a signed  driver at " << drv.DriverPath() << " and have administrator rights to run this program" << std::endl;
         return;
     }
 #endif

--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -1725,7 +1725,7 @@ PCM::PCM() :
     if (!drv.start())
     {
         std::wcerr << "Cannot access CPU counters" << std::endl;
-        std::wcerr << "You must have a signed  driver at " << drv.DriverPath() << " and have administrator rights to run this program" << std::endl;
+        std::wcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program" << std::endl;
         return;
     }
 #endif

--- a/pcm-memory.cpp
+++ b/pcm-memory.cpp
@@ -775,12 +775,6 @@ int main(int argc, char * argv[])
     std::cerr.rdbuf(&nullStream2);
 #endif
 
-#ifdef _MSC_VER
-    TCHAR driverPath[1040]; // length for current directory + "\\msr.sys"
-    GetCurrentDirectory(1024, driverPath);
-    wcscat_s(driverPath, 1040, L"\\msr.sys");
-#endif
-
     cerr << endl;
     cerr << " Processor Counter Monitor: Memory Bandwidth Monitoring Utility " << PCM_VERSION << endl;
     cerr << endl;
@@ -911,11 +905,11 @@ int main(int argc, char * argv[])
         else
         if (strncmp(*argv, "--installDriver", 15) == 0)
         {
-            Driver tmpDrvObject;
-            if (!tmpDrvObject.start(driverPath))
+            Driver tmpDrvObject = Driver(Driver::msrLocalPath());
+            if (!tmpDrvObject.start())
             {
-                cerr << "Can not access CPU counters" << endl;
-                cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << endl;
+                wcerr << "Can not access CPU counters" << endl;
+                wcerr << "You must have a signed  driver at " << tmpDrvObject.DriverPath() << " and have administrator rights to run this program" << endl;
                 exit(EXIT_FAILURE);
             }
             exit(EXIT_SUCCESS);

--- a/pcm-memory.cpp
+++ b/pcm-memory.cpp
@@ -909,7 +909,7 @@ int main(int argc, char * argv[])
             if (!tmpDrvObject.start())
             {
                 wcerr << "Can not access CPU counters" << endl;
-                wcerr << "You must have a signed  driver at " << tmpDrvObject.DriverPath() << " and have administrator rights to run this program" << endl;
+                wcerr << "You must have a signed  driver at " << tmpDrvObject.driverPath() << " and have administrator rights to run this program" << endl;
                 exit(EXIT_FAILURE);
             }
             exit(EXIT_SUCCESS);

--- a/pcm-msr.cpp
+++ b/pcm-msr.cpp
@@ -98,7 +98,7 @@ int main(int argc, char * argv[])
     if (!drv.start())
     {
         std::wcerr << "Can not load MSR driver." << std::endl;
-        std::wcerr << "You must have a signed  driver at " << drv.DriverPath() << " and have administrator rights to run this program" << std::endl;
+        std::wcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program" << std::endl;
         return -1;
     }
     #endif

--- a/pcm-msr.cpp
+++ b/pcm-msr.cpp
@@ -92,17 +92,13 @@ int main(int argc, char * argv[])
     // Increase the priority a bit to improve context switching delays on Windows
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 
-    TCHAR driverPath[1032];
-    GetCurrentDirectory(1024, driverPath);
-    wcscat_s(driverPath, 1032, L"\\msr.sys");
-
     // WARNING: This driver code (msr.sys) is only for testing purposes, not for production use
-    Driver drv;
+    Driver drv = Driver(Driver::msrLocalPath());
     // drv.stop();     // restart driver (usually not needed)
-    if (!drv.start(driverPath))
+    if (!drv.start())
     {
-        std::cerr << "Can not load MSR driver." << std::endl;
-        std::cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
+        std::wcerr << "Can not load MSR driver." << std::endl;
+        std::wcerr << "You must have a signed  driver at " << drv.DriverPath() << " and have administrator rights to run this program" << std::endl;
         return -1;
     }
     #endif

--- a/pcm-pcicfg.cpp
+++ b/pcm-pcicfg.cpp
@@ -102,7 +102,7 @@ int main(int argc, char * argv[])
     if (!drv.start())
     {
         std::wcerr << "Can not load MSR driver." << std::endl;
-        std::wcerr << "You must have a signed  driver at " << drv.DriverPath() << " and have administrator rights to run this program" << std::endl;
+        std::wcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program" << std::endl;
         return -1;
     }
     #endif

--- a/pcm-pcicfg.cpp
+++ b/pcm-pcicfg.cpp
@@ -96,17 +96,13 @@ int main(int argc, char * argv[])
     // Increase the priority a bit to improve context switching delays on Windows
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 
-    TCHAR driverPath[1032];
-    GetCurrentDirectory(1024, driverPath);
-    wcscat_s(driverPath, 1032, L"\\msr.sys");
-
     // WARNING: This driver code (msr.sys) is only for testing purposes, not for production use
-    Driver drv;
+    Driver drv = Driver(Driver::msrLocalPath());
     // drv.stop();     // restart driver (usually not needed)
-    if (!drv.start(driverPath))
+    if (!drv.start())
     {
-        std::cerr << "Can not load MSR driver." << std::endl;
-        std::cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << std::endl;
+        std::wcerr << "Can not load MSR driver." << std::endl;
+        std::wcerr << "You must have a signed  driver at " << drv.DriverPath() << " and have administrator rights to run this program" << std::endl;
         return -1;
     }
     #endif

--- a/pcm.cpp
+++ b/pcm.cpp
@@ -1170,7 +1170,7 @@ int main(int argc, char * argv[])
             if (!tmpDrvObject.start())
             {
                 wcerr << "Can not access CPU counters" << endl;
-                wcerr << "You must have a signed  driver at " << tmpDrvObject.DriverPath() << " and have administrator rights to run this program" << endl;
+                wcerr << "You must have a signed  driver at " << tmpDrvObject.driverPath() << " and have administrator rights to run this program" << endl;
                 exit(EXIT_FAILURE);
             }
             exit(EXIT_SUCCESS);

--- a/pcm.cpp
+++ b/pcm.cpp
@@ -1166,14 +1166,11 @@ int main(int argc, char * argv[])
         else
         if (strncmp(*argv, "--installDriver", 15) == 0)
         {
-            TCHAR driverPath[1040]; // length for current directory + "\\msr.sys"
-            GetCurrentDirectory(1024, driverPath);
-            wcscat_s(driverPath, 1040, L"\\msr.sys");
-            Driver tmpDrvObject;
-            if (!tmpDrvObject.start(driverPath))
+            Driver tmpDrvObject = Driver(Driver::msrLocalPath());
+            if (!tmpDrvObject.start())
             {
-                cerr << "Can not access CPU counters" << endl;
-                cerr << "You must have signed msr.sys driver in your current directory and have administrator rights to run this program" << endl;
+                wcerr << "Can not access CPU counters" << endl;
+                wcerr << "You must have a signed  driver at " << tmpDrvObject.DriverPath() << " and have administrator rights to run this program" << endl;
                 exit(EXIT_FAILURE);
             }
             exit(EXIT_SUCCESS);


### PR DESCRIPTION
Similar to #138 but allows the driver load location and name to be configured via registry on Windows. This would permit a driver offering the same API to be used from a different location on the system and detected by all pcm applications. When in use the error messages given by applications will contain the expected path of the driver.

This has been tested for several scenarios: multiple driver locations, overwriting existing driver, name change. All behavior remains consistent with prior to this change.

Code to support this has only been added to windows specific code so should have no impact on Linux/OSX applications.