### PR TITLE
pcm-iio bug fixes

### DIFF
--- a/opCode.txt
+++ b/opCode.txt
@@ -8,14 +8,14 @@ ctr=1,ev_sel=0x83,umask=0x4,en=1,ch_mask=2,fc_mask=0x7,multiplier=4,divider=1,hn
 ctr=0,ev_sel=0x83,umask=0x4,en=1,ch_mask=4,fc_mask=0x7,multiplier=4,divider=1,hname=IB read,vname=Part2 (2nd x8/3rd x4)
 ctr=1,ev_sel=0x83,umask=0x4,en=1,ch_mask=8,fc_mask=0x7,multiplier=4,divider=1,hname=IB read,vname=Part3 (4th x4)
 # Outbound (CPU MMIO to the PCIe device) payload events
-ctr=2,ev_sel=0xc0,umask=0x4,en=1,ch_mask=1,fc_mask=0x7,multiplier=1,divider=1,hname=OB read,vname=Part0 (1st x16/x8/x4)
-ctr=3,ev_sel=0xc0,umask=0x4,en=1,ch_mask=2,fc_mask=0x7,multiplier=1,divider=1,hname=OB read,vname=Part1 (2nd x4)
-ctr=2,ev_sel=0xc0,umask=0x4,en=1,ch_mask=4,fc_mask=0x7,multiplier=1,divider=1,hname=OB read,vname=Part2 (2nd x8/3rd x4)
-ctr=3,ev_sel=0xc0,umask=0x4,en=1,ch_mask=8,fc_mask=0x7,multiplier=1,divider=1,hname=OB read,vname=Part3 (4th x4)
-ctr=2,ev_sel=0xc0,umask=0x1,en=1,ch_mask=1,fc_mask=0x7,multiplier=1,divider=1,hname=OB write,vname=Part0 (1st x16/x8/x4)
-ctr=3,ev_sel=0xc0,umask=0x1,en=1,ch_mask=2,fc_mask=0x7,multiplier=1,divider=1,hname=OB write,vname=Part1 (2nd x4)
-ctr=2,ev_sel=0xc0,umask=0x1,en=1,ch_mask=4,fc_mask=0x7,multiplier=1,divider=1,hname=OB write,vname=Part2 (2nd x8/3rd x4)
-ctr=3,ev_sel=0xc0,umask=0x1,en=1,ch_mask=8,fc_mask=0x7,multiplier=1,divider=1,hname=OB write,vname=Part3 (4th x4)
+ctr=2,ev_sel=0xc0,umask=0x4,en=1,ch_mask=1,fc_mask=0x7,multiplier=4,divider=1,hname=OB read,vname=Part0 (1st x16/x8/x4)
+ctr=3,ev_sel=0xc0,umask=0x4,en=1,ch_mask=2,fc_mask=0x7,multiplier=4,divider=1,hname=OB read,vname=Part1 (2nd x4)
+ctr=2,ev_sel=0xc0,umask=0x4,en=1,ch_mask=4,fc_mask=0x7,multiplier=4,divider=1,hname=OB read,vname=Part2 (2nd x8/3rd x4)
+ctr=3,ev_sel=0xc0,umask=0x4,en=1,ch_mask=8,fc_mask=0x7,multiplier=4,divider=1,hname=OB read,vname=Part3 (4th x4)
+ctr=2,ev_sel=0xc0,umask=0x1,en=1,ch_mask=1,fc_mask=0x7,multiplier=4,divider=1,hname=OB write,vname=Part0 (1st x16/x8/x4)
+ctr=3,ev_sel=0xc0,umask=0x1,en=1,ch_mask=2,fc_mask=0x7,multiplier=4,divider=1,hname=OB write,vname=Part1 (2nd x4)
+ctr=2,ev_sel=0xc0,umask=0x1,en=1,ch_mask=4,fc_mask=0x7,multiplier=4,divider=1,hname=OB write,vname=Part2 (2nd x8/3rd x4)
+ctr=3,ev_sel=0xc0,umask=0x1,en=1,ch_mask=8,fc_mask=0x7,multiplier=4,divider=1,hname=OB write,vname=Part3 (4th x4)
 # VTd events
 ctr=0,ev_sel=0x41,umask=0x20,en=1,ch_mask=1,fc_mask=0x7,multiplier=1,divider=1,hname=TLB Miss,vname=Total
 ctr=1,ev_sel=0x41,umask=0x10,en=1,ch_mask=1,fc_mask=0x7,multiplier=1,divider=1,hname=VT-d L3 Miss,vname=Total

--- a/pcm-iio.cpp
+++ b/pcm-iio.cpp
@@ -282,7 +282,7 @@ void discover_pci_tree(const vector<uint32_t> & busno, uint8_t socket_id, vector
             uint8_t busno = iio_skx.stacks[stack].busno;
             iio_skx.stacks[stack].stack_name = iio_stack_names[stack];
             //std::cout << "stack" << unsigned(stack) << std::hex << ":0x" << unsigned(busno) << std::dec << ",(" << unsigned(busno) << ")\n";
-            for (uint8_t part = 0; part < 3; part++) {
+            for (uint8_t part = 0; part < 4; part++) {
                 struct pci *pci = &iio_skx.stacks[stack].parts[part].root_pci_dev;
                 struct bdf *bdf = &pci->bdf;
                 bdf->busno = busno;


### PR DESCRIPTION
Minor fixes to
1. count the number of OB bytes
1. scan all possible ports of PCIe bridges