### PR TITLE
fix corrupted memory usage in pcm-xxx tools

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -1645,7 +1645,7 @@ class CoreTaskQueue
     CoreTaskQueue(CoreTaskQueue &) = delete;
 public:
     CoreTaskQueue(int32 core) :
-        worker([&]() {
+        worker([=]() {
             TemporalThreadAffinity tempThreadAffinity(core);
             std::unique_lock<std::mutex> lock(m);
             while (1) {


### PR DESCRIPTION
The code was creating a lambda function taking by reference the
core local variable, and passing it to a thread that often
executes after constructor has exited causing per-core thread
to use a corrupted core_id.

Depending on compiler and runtime timing, gdb or not,
the tool might randomly segfault or have incorrect behavior.

This makes sure the lambda function takes copy of automatic variable
in enclosing environment, for future execution in new
thread context.

Tested: crash without patch, ok with patch
Signed-off-by: Loic Prylli <lprylli@netflix.com>