### PR TITLE
Don't use _exit in normal program termination

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -47,9 +47,6 @@ void exit_cleanup(void)
     {
         post_cleanup_callback();
     }
-
-// now terminate the program immediately
-    _exit(EXIT_SUCCESS);
 }
 
 void print_cpu_details()
@@ -138,6 +135,7 @@ BOOL sigINT_handler(DWORD fdwCtrlType)
         return FALSE;
     } else {
         exit_cleanup();
+        _exit(EXIT_SUCCESS);
         return FALSE; // to prevent Warning
     }
 }
@@ -169,10 +167,12 @@ void sigINT_handler(int signum)
 
     // in case PCM is blocked just return and summary will be dumped in
     // calling function, if needed
-    if (PCM::getInstance()->isBlocked())
+    if (PCM::getInstance()->isBlocked()) {
         return;
-    else
+    } else {
         exit_cleanup();
+        _exit(EXIT_SUCCESS);
+    }
 }
 
 /**


### PR DESCRIPTION
It is unnecessary to call _exit from the exit handler function.
Always using _exit breaks tools like gprof that require a normal exit call.
The sigINT_handler functions still call _exit, but this is just to preserve
the existing design for signal handling.
It may be desirable to call _exit for signals like SIGQUIT but not SIGINT.