### PR TITLE
[pcm] change default install paths for mac os to /usr/local/*

### DIFF
--- a/MacMSRDriver/Makefile
+++ b/MacMSRDriver/Makefile
@@ -15,15 +15,15 @@ library:
 
 install: clean kext library
 	sudo sh ./kextload.sh
-	sudo mkdir -p /usr/include /usr/lib
-	sudo cp build/Release/libPcmMsr.dylib /usr/lib/
-	sudo cp MSRAccessorPublic.h /usr/include/MSRAccessor.h
-	sudo cp MSRKernel.h /usr/include/MSRKernel.h
-	sudo cp PCIDriverInterface.h /usr/include/PCIDriverInterface.h
+	sudo mkdir -p /usr/local/include /usr/local/lib
+	sudo cp build/Release/libPcmMsr.dylib /usr/local/lib/
+	sudo cp MSRAccessorPublic.h /usr/local/include/MSRAccessor.h
+	sudo cp MSRKernel.h /usr/local/include/MSRKernel.h
+	sudo cp PCIDriverInterface.h /usr/local/include/PCIDriverInterface.h
 
 uninstall:
 	sudo sh ./kextunload.sh
-	sudo rm /usr/include/MSRKernel.h
-	sudo rm /usr/include/MSRAccessor.h
-	sudo rm /usr/lib/libPcmMsr.dylib
-	sudo rm /usr/include/PCIDriverInterface.h
+	sudo rm /usr/local/include/MSRKernel.h
+	sudo rm /usr/local/include/MSRAccessor.h
+	sudo rm /usr/local/lib/libPcmMsr.dylib
+	sudo rm /usr/local/include/PCIDriverInterface.h


### PR DESCRIPTION
Since El Capitan /usr/lib & /usr/include are not writable even for root: https://support.apple.com/en-us/HT204899,
thus, running `make install` fails.

/usr/local/lib still is writable, and seems like a better option for a
default install script.

Test plan:
1) make uninstall old version, for which i copied files manually;
2) make install for new version
3) build pcm.x
4) run it, confirm it works.