### PR TITLE
[pcm] check counter_num_max before setting counter_num_used

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -2144,8 +2144,11 @@ PCM::ErrorCode PCM::program(const PCM::ProgramMode mode_, const void * parameter
         if (isAtom() == false && cpu_model != KNL)
         {
             coreEventDesc[2] = pDesc[2];
-            coreEventDesc[3] = pDesc[3];
-            core_gen_counter_num_used = 4;
+            core_gen_counter_num_used = 3;
+            if (core_gen_counter_num_max > 3) {
+                coreEventDesc[3] = pDesc[3];
+                core_gen_counter_num_used = 4;
+            }
         }
         else
             core_gen_counter_num_used = 2;


### PR DESCRIPTION
Hi, I'm trying to run a test app to measure custom system-wide counters for 1 second. Here's the code:

```
#include <cpucounters.h>
#include <iostream>

int main() {
  PCM *m = PCM::getInstance();
  PCM::CustomCoreEventDescription evt[4];
  std::cout << m->getCPUModel() << std::endl;
  
  // UOPS_ISSUED.ANY
  evt[0].event_number = 0x0E;
  evt[0].umask_value = 0x01;

  auto res = m->program (PCM::CUSTOM_CORE_EVENTS, evt);

  SystemCounterState before = getSystemCounterState();
  sleep(1);
  SystemCounterState after = getSystemCounterState();
  std::cout << getNumberOfCustomEvents(0, before, after) << std::endl;

  m->cleanup();
}

```

I'm building it like this:
```
g++ -std=c++2a -O3 -I../opcm/pcm/ /usr/local/lib/libPcmMsr.dylib ../opcm/pcm/cpucounters.o ../opcm/pcm/msr.o ../opcm/pcm/client_bw.o ../opcm/pcm/pci.o ../opcm/pcm/mmio.o ../opcm/pcm/topology.o ../opcm/pcm/threadpool.o ../opcm/pcm/debug.o b.cpp
```

When running it with freshly built pcm, i'm getting error: 
```
PCM ERROR: Trying to program 4 general purpose counters with only 3 available
```

Looking at the code a bit, it seems like we'll indeed pick 4 here:
https://github.com/opcm/pcm/blob/b03e86a0b4d1a19f72470f5e1fc345f5288f8f6f/cpucounters.cpp#L2141-L2151

while only 3 seems to be available for my KBL CPU.

this change fixes the issue and seems to be similar to what's already done in default mode: https://github.com/opcm/pcm/blob/b03e86a0b4d1a19f72470f5e1fc345f5288f8f6f/cpucounters.cpp#L2180-L2189

Do you think it is the right way to fix it? 
