### PR TITLE
Do not run pcm-lspci on non-Skx processors

### DIFF
--- a/cpucounters.h
+++ b/cpucounters.h
@@ -1776,6 +1776,13 @@ public:
             );
     }
 
+    bool isSkxCompatible() const
+    {
+        return (
+            cpu_model == PCM::SKX
+               );
+    }
+
     bool hasUPI() const // Intel(r) Ultra Path Interconnect
     {
         return (

--- a/pcm-lspci.cpp
+++ b/pcm-lspci.cpp
@@ -107,7 +107,13 @@ int main(int /*argc*/, char * /*argv*/[])
 {
     PCIDB pciDB;
     load_PCIDB(pciDB);
-    PCM::getInstance();
+    PCM * m = PCM::getInstance();
+
+    if (!m->isSkxCompatible())
+    {
+        cerr << "Unsupported processor model (" << m->getCPUModel() << ").\n";
+        exit(EXIT_FAILURE);
+    }
     std::cout << "\n Display PCI tree information\n\n";
     for(int bus=0; bus < 256; ++bus)
         scanBus(bus, pciDB);


### PR DESCRIPTION
`pcm-lspci` is very specific to SKX as it explicitly specifies the device number to check by a magic number (8). This PR makes `pcm-lspci` not run on non-SKX processors.