### PR TITLE
init: fail in case PCI CFG space is inaccessible

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -2146,8 +2146,9 @@ PCM::ErrorCode PCM::program(const PCM::ProgramMode mode_, const void * parameter
     }
 
     InstanceLock lock(allow_multiple_instances);
-    if (MSR.empty()) return PCM::MSRAccessDenied;
-
+    if (MSR.empty() || (hasPCICFGUncore() && server_pcicfg_uncore.empty()))
+        return PCM::MSRAccessDenied;
+    
     ExtendedCustomCoreEventDescription * pExtDesc = (ExtendedCustomCoreEventDescription *)parameter_;
 
 #ifdef PCM_USE_PERF


### PR DESCRIPTION
When PCI CFG space is inaccessible (in particular in a VM), PCM becomes
mostly useless, yet, prior to this commit, it could not be directly
identified.

Signed-off-by: Andrey Gelman <andrey.gelman@gmail.com>