### PR TITLE
Specify InfluxDB image tag to resolve authentication error

### DIFF
--- a/grafana/start.sh
+++ b/grafana/start.sh
@@ -23,7 +23,7 @@ echo Downloading PCM dashboard
 curl -o grafana_volume/dashboards/pcm-dashboard.json $1/dashboard
 
 echo Starting influxdb
-docker run -d --name influxdb -p 8083:8083 -p 8086:8086 -v $PWD/influxdb_volume:/var/lib/influxdb influxdb
+docker run -d --name influxdb -p 8083:8083 -p 8086:8086 -v $PWD/influxdb_volume:/var/lib/influxdb influxdb:1.8.0-alpine
 echo Starting telegraf
 docker run -d --name telegraf --link=influxdb -v $PWD/telegraf.conf:/etc/telegraf/telegraf.conf:ro telegraf
 echo Starting grafana


### PR DESCRIPTION
The latest `influxdb` image requires authentication method when linked with telegraf and generates the following error from the `telegraf` side.

```
When writing to [http://influxdb:8086]: 401 Unauthorized
```

I've tested with `1.8.0-alpine` tag and seems to work.

