### PR TITLE
[make] Do not build dependencies in clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,9 @@ daemon-binaries:
 
 klocwork: $(EXE)
 
+ifneq ($(MAKECMDGOALS),clean)
 -include $(OBJS:.o=.d)
+endif
 libPCM.a: $(COMMON_OBJS)
 	ar -rcs $@ $^
 


### PR DESCRIPTION
Do not build dependency files in clean Makefile target.