### PR TITLE
Split out the generated version define.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-cpucounters.h export-subst
+version.h export-subst
 .cirrus.yml export-ignore
 .gitlab-ci.yml export-ignore
 .travis.yml export-ignore

--- a/cpucounters.h
+++ b/cpucounters.h
@@ -22,7 +22,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
         Include this header file if you want to access CPU counters (core and uncore - including memory controller chips and QPI)
 */
 
-#define PCM_VERSION " ($Format:%ci ID=%h$)"
+#include "version.h"
 
 #ifndef PCM_API
 #define PCM_API

--- a/version.h
+++ b/version.h
@@ -1,0 +1,1 @@
+#define PCM_VERSION " ($Format:%ci ID=%h$)"


### PR DESCRIPTION
A generated file should be as simple as possible, otherwise it makes downstream packaging unfun.