### PR TITLE
fix assert failed in build_bit_ui on vm

### DIFF
--- a/cpucounters.cpp
+++ b/cpucounters.cpp
@@ -1124,7 +1124,7 @@ bool PCM::discoverSystemTopology()
     auto populateEntry = [&smtMaskWidth, &coreMaskWidth, &l2CacheMaskShift](TopologyEntry & entry, const int apic_id)
     {
         entry.thread_id = smtMaskWidth ? extract_bits_ui(apic_id, 0, smtMaskWidth - 1) : 0;
-        entry.core_id = extract_bits_ui(apic_id, smtMaskWidth, smtMaskWidth + coreMaskWidth - 1);
+        entry.core_id = (smtMaskWidth + coreMaskWidth) ? extract_bits_ui(apic_id, smtMaskWidth, smtMaskWidth + coreMaskWidth - 1) : 0;
         entry.socket = extract_bits_ui(apic_id, smtMaskWidth + coreMaskWidth, 31);
         entry.tile_id = extract_bits_ui(apic_id, l2CacheMaskShift, 31);
     };


### PR DESCRIPTION
Detected a hypervisor/virtualization technology. Some metrics might not be available due to configuration or availability of virtual hardware features.
Linux arch_perfmon flag  : yes
IBRS and IBPB supported  : yes
STIBP supported          : yes
Spec arch caps supported : yes
pcm: cpucounters.cpp:316: pcm::uint32 pcm::build_bit_ui(pcm::uint32, pcm::uint32): Assertion `end <= 31' failed.

Signed-off-by: jingrui <jingrui@huawei.com>