### PR TITLE
Make `WinPMem::LogError()` take a const pointer

### DIFF
--- a/winpmem/winpmem.cpp
+++ b/winpmem/winpmem.cpp
@@ -86,7 +86,7 @@ WinPmem::~WinPmem() {
   }
 }
 
-void WinPmem::LogError(TCHAR *message) {
+void WinPmem::LogError(const TCHAR *message) {
   _tcsncpy_s(last_error, message, sizeof(last_error));
   if (suppress_output) return;
 

--- a/winpmem/winpmem.h
+++ b/winpmem/winpmem.h
@@ -71,7 +71,7 @@ class WinPmem {
  protected:
   virtual int load_driver_() = 0;
 
-  virtual void LogError(TCHAR *message);
+  virtual void LogError(const TCHAR *message);
   virtual void Log(const TCHAR *message, ...);
 
   // The file handle to the pmem device.


### PR DESCRIPTION
Fixes #328.

This resolves a `const`ness issue where `winpmem.h` would pass string literals to `LogError()`, when that function expected a mutable pointer.

As this function only uses it as a `const` pointer, this just makes it take a `const` pointer instead.

If this isn't a viable solution (e.g. if there are binary compatibility issues I've overlooked or something), then an alternative solution could be to `const_cast` all the string literals in `winpmem.h` that get passed to this function.