### PR TITLE
fix installation path for pcm-bw-histogram.sh

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,7 +145,7 @@ if(UNIX) # APPLE, LINUX, FREE_BSD
 
     # Install extra files
     install(FILES pcm-bw-histogram.sh
-            DESTINATION "sbin/pcm-bw-histogram"
+            DESTINATION "sbin"
             PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
     file(GLOB OPCODE_FILES "opCode*.txt")
     foreach(opcode_file ${OPCODE_FILES})


### PR DESCRIPTION
don't install into sbin/pcm-bw-histogram/ directory
install into sbin/ directory