### PR TITLE
pcm-sensor: quit on EOF

### DIFF
--- a/src/pcm-sensor.cpp
+++ b/src/pcm-sensor.cpp
@@ -672,7 +672,7 @@ int main()
         OUTPUT_SYSTEM_METRIC("QPI_Traffic", (double(counters.getSystem<uint64, ::getAllIncomingQPILinkBytes>()) / 1024 / 1024 / 1024))
 
         // exit
-        if (s == "quit" || s == "exit") {
+        if (s == "quit" || s == "exit" || s == "") {
             break;
         }
 


### PR DESCRIPTION
Prevents entering an infinite loop upon receiving ^D.