### PR TITLE
fix a bashism

### DIFF
--- a/src/pcm-bw-histogram.sh
+++ b/src/pcm-bw-histogram.sh
@@ -18,7 +18,7 @@ rm $out
 echo
 echo ========= CHECKING FOR PMM SUPPORT =========
 echo
-./pcm-memory -pmm -- sleep 1 &> tmp
+./pcm-memory -pmm -- sleep 1 >tmp 2>&1
 dram_only=`cat tmp | grep "PMM traffic metrics are not available"  | wc -l`
 rm tmp
 if [ $dram_only -gt 0 ]


### PR DESCRIPTION
The `&>` syntax is a bash feature, while this script uses POSIX sh instead.  On some distros (Fedora, Red Hat) /bin/sh points to bash, but eg. on Debian, Ubuntu it's dash, elsewhere it might be busybox, mksh, etc.

So we need to either change hashbang to `#!/bin/bash` or use a portable syntax.