### PR TITLE
CMake: Use system simdjson when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,19 @@ if(UNIX)  # APPLE, LINUX, FREE_BSD
 
 endif(UNIX)
 
+# interface library for simdjson
+add_library(PCM_SIMDJSON INTERFACE)
+find_package(simdjson QUIET)
+if(simdjson_FOUND)
+    target_link_libraries(PCM_SIMDJSON INTERFACE simdjson::simdjson)
+    target_compile_definitions(PCM_SIMDJSON INTERFACE SYSTEM_SIMDJSON)
+else()
+    message("simdjson not found in system, falling back to wrapper")
+    file(GLOB SIMDJSON_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/src/simdjson_wrapper.cpp)
+    target_sources(PCM_SIMDJSON INTERFACE ${SIMDJSON_SOURCE})
+    target_include_directories(PCM_SIMDJSON INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+endif(simdjson_FOUND)
+
 #######################
 # Install
 #######################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,30 +88,30 @@ endif(MSVC)
 
 foreach(PROJECT_NAME ${PROJECT_NAMES})
     file(GLOB PROJECT_FILE ${PROJECT_NAME}.cpp)
+    set(LIBS PCM_STATIC)
+
+    add_executable(${PROJECT_NAME} ${PROJECT_FILE})
 
     # specific file for pcm-raw project
     if(${PROJECT_NAME} STREQUAL pcm-raw)
-        file(GLOB SIMDJSON_SOURCE simdjson_wrapper.cpp) 
-        add_executable(${PROJECT_NAME} ${PROJECT_FILE} ${SIMDJSON_SOURCE})
-    else()
-        add_executable(${PROJECT_NAME} ${PROJECT_FILE})
+        set(LIBS ${LIBS} PCM_SIMDJSON)
     endif(${PROJECT_NAME} STREQUAL pcm-raw)
 
     if(LINUX OR FREE_BSD)
-        target_link_libraries(${PROJECT_NAME} PRIVATE PCM_STATIC Threads::Threads)
+        set(LIBS ${LIBS} Threads::Threads)
         install(TARGETS ${PROJECT_NAME} DESTINATION "sbin")
     endif(LINUX OR FREE_BSD)
 
     if(APPLE)
-        target_link_libraries(${PROJECT_NAME} PRIVATE PCM_STATIC Threads::Threads PcmMsr)
+        set(LIBS ${LIBS} Threads::Threads PcmMsr)
         install(TARGETS ${PROJECT_NAME} DESTINATION "sbin")
     endif(APPLE)
 
     if(MSVC)
         target_compile_definitions(${PROJECT_NAME} PRIVATE _UNICODE UNICODE _CONSOLE) # for all, except pcm-lib and pcm-service
-        target_link_libraries(${PROJECT_NAME} PRIVATE PCM_STATIC)
     endif(MSVC)
 
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBS})
 endforeach(PROJECT_NAME ${PROJECT_NAMES})
 
 #######################

--- a/src/simdjson_wrapper.h
+++ b/src/simdjson_wrapper.h
@@ -7,7 +7,10 @@
 #endif
 
 #ifndef PCM_GCC_6_OR_BELOW
-    #if defined __has_include
+    #if defined SYSTEM_SIMDJSON
+        #include <simdjson.h>
+        #define PCM_SIMDJSON_AVAILABLE
+    #elif defined __has_include
         #if __has_include ("simdjson/singleheader/simdjson.h")
             #pragma warning(push, 0)
             #include "simdjson/singleheader/simdjson.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ if(UNIX)
 
     # PCM_STATIC + pcm_sensor + simdjson_obj = urltest
     if(LINUX)
-        add_executable(urltest urltest.cpp ../src/simdjson_wrapper.cpp)
-        target_link_libraries(urltest Threads::Threads PCM_STATIC)
+        add_executable(urltest urltest.cpp)
+        target_link_libraries(urltest Threads::Threads PCM_SIMDJSON PCM_STATIC)
     endif(LINUX)
 
 endif(UNIX)


### PR DESCRIPTION
This change adds an interface library `PCM_SIMDJSON`. It depends on the system-wide instance of `simdjson` if available. Otherwise, it pulls in the wrapper.

Fixes #384.