### PR TITLE
Handle non-Unicode configurations

### DIFF
--- a/src/cpucounters.cpp
+++ b/src/cpucounters.cpp
@@ -103,8 +103,8 @@ bool PCM::initWinRing0Lib()
 
     BYTE major, minor, revision, release;
     GetDriverVersion(&major, &minor, &revision, &release);
-    wchar_t buffer[128];
-    swprintf_s(buffer, 128, _T("\\\\.\\WinRing0_%d_%d_%d"),(int)major,(int)minor, (int)revision);
+    TCHAR buffer[128];
+    _stprintf_s(buffer, 128, TEXT("\\\\.\\WinRing0_%d_%d_%d"),(int)major,(int)minor, (int)revision);
     restrictDriverAccess(buffer);
 
     return true;
@@ -1087,11 +1087,11 @@ bool PCM::discoverSystemTopology()
         }
         else
         {
-            std::wcerr << "Error in Windows function 'GetLogicalProcessorInformationEx': " <<
+            tcerr << "Error in Windows function 'GetLogicalProcessorInformationEx': " <<
                 GetLastError() << " ";
             const TCHAR * strError = _com_error(GetLastError()).ErrorMessage();
-            if (strError) std::wcerr << strError;
-            std::wcerr << "\n";
+            if (strError) tcerr << strError;
+            tcerr << "\n";
             return false;
         }
     }
@@ -2121,8 +2121,8 @@ PCM::PCM() :
     // drv.stop();     // restart driver (usually not needed)
     if (!drv.start())
     {
-        std::wcerr << "Cannot access CPU counters\n";
-        std::wcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program\n";
+        tcerr << "Cannot access CPU counters\n";
+        tcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program\n";
         return;
     }
 #endif

--- a/src/cpucounters.h
+++ b/src/cpucounters.h
@@ -66,7 +66,7 @@
 namespace pcm {
 
 #ifdef _MSC_VER
-void PCM_API restrictDriverAccess(LPCWSTR path);
+void PCM_API restrictDriverAccess(LPCTSTR path);
 #endif
 
 class SystemCounterState;

--- a/src/mmio.cpp
+++ b/src/mmio.cpp
@@ -43,7 +43,7 @@ protected:
         switch (sys_info.wProcessorArchitecture)
         {
         case PROCESSOR_ARCHITECTURE_AMD64:
-            wcscat_s(driver_filename, MAX_PATH, L"\\winpmem_x64.sys");
+            _tcscat_s(driver_filename, MAX_PATH, TEXT("\\winpmem_x64.sys"));
             if (GetFileAttributes(driver_filename) == INVALID_FILE_ATTRIBUTES)
             {
                 std::cerr << "ERROR: winpmem_x64.sys not found in current directory. Download it from https://github.com/Velocidex/WinPmem/blob/master/kernel/binaries/winpmem_x64.sys .\n";
@@ -51,7 +51,7 @@ protected:
             }
             break;
         case PROCESSOR_ARCHITECTURE_INTEL:
-            wcscat_s(driver_filename, MAX_PATH, L"\\winpmem_x86.sys");
+            _tcscat_s(driver_filename, MAX_PATH, TEXT("\\winpmem_x86.sys"));
             if (GetFileAttributes(driver_filename) == INVALID_FILE_ATTRIBUTES)
             {
                 std::cerr << "ERROR: winpmem_x86.sys not found in current directory. Download it from https://github.com/Velocidex/WinPmem/blob/master/kernel/binaries/winpmem_x86.sys .\n";

--- a/src/pcm-memory.cpp
+++ b/src/pcm-memory.cpp
@@ -1123,8 +1123,8 @@ int main(int argc, char * argv[])
             Driver tmpDrvObject = Driver(Driver::msrLocalPath());
             if (!tmpDrvObject.start())
             {
-                wcerr << "Can not access CPU counters\n";
-                wcerr << "You must have a signed  driver at " << tmpDrvObject.driverPath() << " and have administrator rights to run this program\n";
+                tcerr << "Can not access CPU counters\n";
+                tcerr << "You must have a signed  driver at " << tmpDrvObject.driverPath() << " and have administrator rights to run this program\n";
                 exit(EXIT_FAILURE);
             }
             exit(EXIT_SUCCESS);

--- a/src/pcm-msr.cpp
+++ b/src/pcm-msr.cpp
@@ -83,8 +83,8 @@ int main(int argc, char * argv[])
     // drv.stop();     // restart driver (usually not needed)
     if (!drv.start())
     {
-        std::wcerr << "Can not load MSR driver.\n";
-        std::wcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program\n";
+        tcerr << "Can not load MSR driver.\n";
+        tcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program\n";
         return -1;
     }
     #endif

--- a/src/pcm-pcicfg.cpp
+++ b/src/pcm-pcicfg.cpp
@@ -83,8 +83,8 @@ int main(int argc, char * argv[])
     // drv.stop();     // restart driver (usually not needed)
     if (!drv.start())
     {
-        std::wcerr << "Can not load MSR driver.\n";
-        std::wcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program\n";
+        tcerr << "Can not load MSR driver.\n";
+        tcerr << "You must have a signed  driver at " << drv.driverPath() << " and have administrator rights to run this program\n";
         return -1;
     }
     #endif

--- a/src/pcm.cpp
+++ b/src/pcm.cpp
@@ -1306,8 +1306,8 @@ int main(int argc, char * argv[])
             Driver tmpDrvObject = Driver(Driver::msrLocalPath());
             if (!tmpDrvObject.start())
             {
-                wcerr << "Can not access CPU counters\n";
-                wcerr << "You must have a signed  driver at " << tmpDrvObject.driverPath() << " and have administrator rights to run this program\n";
+                tcerr << "Can not access CPU counters\n";
+                tcerr << "You must have a signed  driver at " << tmpDrvObject.driverPath() << " and have administrator rights to run this program\n";
                 exit(EXIT_FAILURE);
             }
             exit(EXIT_SUCCESS);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -264,18 +264,18 @@ void set_signal_handlers(void)
 // to fix Cygwin/BASH setting Ctrl+C handler need first to restore the default one
     handlerStatus = SetConsoleCtrlHandler(NULL, FALSE); // restores normal processing of CTRL+C input
     if (handlerStatus == 0) {
-        std::wcerr << "Failed to set Ctrl+C handler. Error code: " << GetLastError() << " ";
+        tcerr << "Failed to set Ctrl+C handler. Error code: " << GetLastError() << " ";
         const TCHAR * errorStr = _com_error(GetLastError()).ErrorMessage();
-        if (errorStr) std::wcerr << errorStr;
-        std::wcerr << "\n";
+        if (errorStr) tcerr << errorStr;
+        tcerr << "\n";
         _exit(EXIT_FAILURE);
     }
     handlerStatus = SetConsoleCtrlHandler((PHANDLER_ROUTINE)sigINT_handler, TRUE);
     if (handlerStatus == 0) {
-        std::wcerr << "Failed to set Ctrl+C handler. Error code: " << GetLastError() << " ";
+        tcerr << "Failed to set Ctrl+C handler. Error code: " << GetLastError() << " ";
         const TCHAR * errorStr = _com_error(GetLastError()).ErrorMessage();
-        if (errorStr) std::wcerr << errorStr;
-        std::wcerr << "\n";
+        if (errorStr) tcerr << errorStr;
+        tcerr << "\n";
         _exit(EXIT_FAILURE);
     }
     SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER)&unhandled_exception_handler);

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,6 +29,15 @@
 
 namespace pcm {
 
+#ifdef _MSC_VER
+    using tstring = std::basic_string<TCHAR>;
+#ifdef UNICODE
+    static auto& tcerr = std::wcerr;
+#else
+    static auto& tcerr = std::cerr;
+#endif
+#endif // _MSC_VER
+
 void exit_cleanup(void);
 void set_signal_handlers(void);
 void set_real_time_priority(const bool & silent);
@@ -80,7 +89,7 @@ void MySystem(char * sysCmd, char ** argc);
 #endif
 struct null_stream : public std::streambuf
 {
-    void overflow(char) { }
+    int_type overflow(int_type) override { return {}; }
 };
 #ifdef __GCC__
 #pragma GCC diagnostic pop
@@ -474,7 +483,7 @@ std::string safe_getenv(const char* env);
 #ifdef _MSC_VER
 inline HANDLE openMSRDriver()
 {
-    return CreateFile(L"\\\\.\\RDMSR", GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+    return CreateFile(TEXT("\\\\.\\RDMSR"), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
 }
 #endif
 

--- a/src/windows/PCMService.h
+++ b/src/windows/PCMService.h
@@ -10,6 +10,11 @@
 #include "pcm-lib.h"
 #include "windriver.h"
 #include <stdexcept>
+
+#ifndef UNICODE
+#include <locale>
+#include <codecvt>
+#endif
 #pragma managed
 
 using namespace pcm;
@@ -743,29 +748,29 @@ namespace PCMServiceNS {
 
             // Read configuration values from registry
             HKEY hkey;
-            if (ERROR_SUCCESS == RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\pcm\\service", NULL, KEY_READ, &hkey))
+            if (ERROR_SUCCESS == RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("SOFTWARE\\pcm\\service"), NULL, KEY_READ, &hkey))
             {
                 DWORD regDWORD = static_cast<DWORD>(REG_DWORD);
                 DWORD lenDWORD = 32;
 
                 DWORD sampleRateRead(0);
-                if (ERROR_SUCCESS == RegQueryValueEx(hkey, L"SampleRate", NULL, NULL, reinterpret_cast<LPBYTE>(&sampleRateRead), &lenDWORD))
+                if (ERROR_SUCCESS == RegQueryValueEx(hkey, TEXT("SampleRate"), NULL, NULL, reinterpret_cast<LPBYTE>(&sampleRateRead), &lenDWORD))
                 {
                     sampleRate = (int)sampleRateRead;
                 }
 
                 DWORD collectCoreRead(0);
-                if (ERROR_SUCCESS == RegQueryValueEx(hkey, L"CollectCore", NULL, NULL, reinterpret_cast<LPBYTE>(&collectCoreRead), &lenDWORD)) {
+                if (ERROR_SUCCESS == RegQueryValueEx(hkey, TEXT("CollectCore"), NULL, NULL, reinterpret_cast<LPBYTE>(&collectCoreRead), &lenDWORD)) {
                     collectionInformation->core = (int)collectCoreRead > 0;
                 }
 
                 DWORD collectSocketRead(0);
-                if (ERROR_SUCCESS == RegQueryValueEx(hkey, L"CollectSocket", NULL, NULL, reinterpret_cast<LPBYTE>(&collectSocketRead), &lenDWORD)) {
+                if (ERROR_SUCCESS == RegQueryValueEx(hkey, TEXT("CollectSocket"), NULL, NULL, reinterpret_cast<LPBYTE>(&collectSocketRead), &lenDWORD)) {
                     collectionInformation->socket = (int)collectSocketRead > 0;
                 }
 
                 DWORD collectQpiRead(0);
-                if (ERROR_SUCCESS == RegQueryValueEx(hkey, L"CollectQpi", NULL, NULL, reinterpret_cast<LPBYTE>(&collectQpiRead), &lenDWORD)) {
+                if (ERROR_SUCCESS == RegQueryValueEx(hkey, TEXT("CollectQpi"), NULL, NULL, reinterpret_cast<LPBYTE>(&collectQpiRead), &lenDWORD)) {
                     collectionInformation->qpi = (int)collectQpiRead > 0;
                 }
 
@@ -778,7 +783,13 @@ namespace PCMServiceNS {
             drv_ = new Driver;
             if (!drv_->start())
             {
-                String^ s = gcnew String((L"Cannot open the driver.\nYou must have a signed driver at " + drv_->driverPath() + L" and have administrator rights to run this program.\n\n").c_str());
+#ifdef UNICODE
+                const auto& driverPath = drv_->driverPath();
+#else
+                std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> char_to_wide;
+                std::wstring driverPath = char_to_wide.from_bytes(drv_->driverPath().c_str());
+#endif
+                String^ s = gcnew String((L"Cannot open the driver.\nYou must have a signed driver at " + driverPath + L" and have administrator rights to run this program.\n\n").c_str());
                 EventLog->WriteEntry(Globals::ServiceName, s, EventLogEntryType::Error);
                 SetServiceFail(ERROR_FILE_NOT_FOUND);
                 throw gcnew Exception(s);

--- a/src/windows/restrictDriverAccess.cpp
+++ b/src/windows/restrictDriverAccess.cpp
@@ -5,8 +5,16 @@
 
 namespace pcm {
 
+#ifdef _MSC_VER
+#ifdef UNICODE
+    static auto& tcerr = std::wcerr;
+#else
+    static auto& tcerr = std::cerr;
+#endif
+#endif // _MSC_VER
+
 //! restrict usage of driver to system (SY) and builtin admins (BA)
-void restrictDriverAccess(LPCWSTR path)
+void restrictDriverAccess(LPCTSTR path)
 {
     try {
         System::Security::AccessControl::FileSecurity^ fSecurity = System::IO::File::GetAccessControl(gcnew System::String(path));
@@ -15,7 +23,7 @@ void restrictDriverAccess(LPCWSTR path)
     }
     catch (...)
     {
-        std::wcerr << "Error in GetAccessControl/SetSecurityDescriptorSddlForm for " << path << " driver.\n";
+        tcerr << "Error in GetAccessControl/SetSecurityDescriptorSddlForm for " << path << " driver.\n";
     }
 }
 

--- a/src/winpmem/winpmem.cpp
+++ b/src/winpmem/winpmem.cpp
@@ -35,7 +35,7 @@
 
 namespace pcm {
 
-extern PCM_API void restrictDriverAccess(LPCWSTR path);
+extern PCM_API void restrictDriverAccess(LPCTSTR path);
 
 int WinPmem::set_acquisition_mode(__int32 mode) {
   DWORD size;
@@ -80,7 +80,7 @@ void WinPmem::LogError(const TCHAR *message) {
   _tcsncpy_s(last_error, message, sizeof(last_error));
   if (suppress_output) return;
 
-  wprintf(L"%s", message);
+  _tprintf(TEXT("%s"), message);
 };
 
 void WinPmem::Log(const TCHAR *message, ...) {
@@ -88,7 +88,7 @@ void WinPmem::Log(const TCHAR *message, ...) {
 
   va_list ap;
   va_start(ap, message);
-  vwprintf(message, ap);
+  _vtprintf(message, ap);
   va_end(ap);
 };
 
@@ -137,7 +137,7 @@ int WinPmem::install_driver(bool delete_driver) {
     }
   }
 
-  Log(L"Loaded Driver %s.\n", driver_filename);
+  Log(TEXT("Loaded Driver %s.\n"), driver_filename);
 
   fd_ = CreateFile(TEXT("\\\\.\\") TEXT(PMEM_DEVICE_NAME),
                    // Write is needed for IOCTL.


### PR DESCRIPTION
Compiles properly when removing UNICODE/_UNICODE defines for the Windows platform.
Can help for integration as an external library in other software.