### PR TITLE
Remove of use of volatile and make memory allocation only for the lif…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ latex/
 *.vcxproj.user
 .vs/
 .idea/
+build
+src/simdjson

--- a/src/MacMSRDriver/PcmMsr/PcmMsr.h
+++ b/src/MacMSRDriver/PcmMsr/PcmMsr.h
@@ -21,7 +21,7 @@ public:
     virtual bool handleIsOpen(const IOService* forClient) const override;
     virtual void handleClose(IOService* forClient, IOOptionBits opts) override;
     
-    virtual uint32_t getNumCores();
+    virtual int32_t getNumCores();
     
     virtual IOReturn incrementNumInstances(uint32_t* num_instances);
     virtual IOReturn decrementNumInstances(uint32_t* num_instances);
@@ -36,8 +36,7 @@ public:
 private:
     // number of providers currently using the driver
     uint32_t num_clients = 0;
-    uint32_t num_cores;
-    topologyEntry *topologies;
+    int32_t num_cores;
 };
 
 #ifdef DEBUG

--- a/src/MacMSRDriver/PcmMsr/UserKernelShared.h
+++ b/src/MacMSRDriver/PcmMsr/UserKernelShared.h
@@ -23,14 +23,14 @@ typedef struct {
 // The topologyEntry struct that is used by PCM
 typedef struct
 {
-    uint32_t os_id;
-    uint32_t thread_id;
-    uint32_t core_id;
-    uint32_t tile_id;
-    uint32_t socket;
-    uint32_t native_cpu_model;
-    uint32_t core_type; // This is an enum in the userland structure.
-    uint32_t padding;
+    int32_t os_id;
+    int32_t thread_id;
+    int32_t core_id;
+    int32_t tile_id;
+    int32_t socket;
+    int32_t native_cpu_model;
+    int32_t core_type; // This is an enum in the userland structure.
+    int32_t padding;
 } topologyEntry;
 
 enum {


### PR DESCRIPTION
…etime of a function that needs it

- Do not use volatile for variables that will not be modified in a way the compiler cannot detect

- Make the buffer used for topologyEntry structures allocated and freed when topology is being built, rather than being allocated for the lifetime of the driver load

- Change macOS TopologyEntry struct to use int rather than uint, which is consistent with the other platforms in this project, as well as macOS's functions.

- Instead of detecting at run time how big of a buffer we will need when issuing a sysctl, always use 4 bytes, which is specified in the docs and examples in kernel source code (see /usr/include/sys/sysctl.h)