### PR TITLE
fix(cmake): Correct macOS KEXT build using absolute SDK paths

### DIFF
--- a/src/MacMSRDriver/PcmMsr/CMakeLists.txt
+++ b/src/MacMSRDriver/PcmMsr/CMakeLists.txt
@@ -18,7 +18,11 @@ if(APPLE)
         COMMAND xcrun --sdk macosx --show-sdk-path
         OUTPUT_VARIABLE MACOSX_SDK_PATH
         OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE XCRUN_RESULT
     )
+    if(NOT XCRUN_RESULT EQUAL 0 OR NOT MACOSX_SDK_PATH)
+        message(FATAL_ERROR "Failed to find macOS SDK path using xcrun")
+    endif()
     message(STATUS "Using SDK for KEXT: ${MACOSX_SDK_PATH}")
 endif()
 


### PR DESCRIPTION
The KEXT (PcmMsrDriver) build failed on macOS because it could not find kernel headers like `<IOKit/IOLib.h>`. This was caused by CMake incorrectly resolving include paths to `/System/Library/...` instead of the correct path inside the macOS SDK.

This commit fixes the issue by localizing the solution to the KEXT's `CMakeLists.txt`. It now dynamically detects the active macOS SDK path using `xcrun` and uses it to construct absolute include paths for the KEXT target only.

This ensures the KEXT can find its required kernel headers without affecting other user-space targets that may depend on libraries from standard locations like Homebrew.

Close: #928