### PR TITLE
[kubernetes] Set hostUsers explicitly

### DIFF
--- a/pcm-kubernetes.yaml.experimental
+++ b/pcm-kubernetes.yaml.experimental
@@ -36,6 +36,7 @@ spec:
         jobLabel: pcm
     spec:
       automountServiceAccountToken: false
+      hostUsers: true
       containers:
       - image: ghcr.io/intel/pcm:latest
         env:


### PR DESCRIPTION
The daemons require host privileges. Setting this explicitly both documentes the incompatibility with user namespaces and ensures, if the default changes, the daemonset will continue to function as expected.