### PR TITLE
[kubernetes] setup networkPolicy for pcm

### DIFF
--- a/pcm-kubernetes.yaml.experimental
+++ b/pcm-kubernetes.yaml.experimental
@@ -50,7 +50,7 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /
-            port: 9738
+            port: pcm-metrics
             scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
@@ -65,7 +65,7 @@ spec:
           failureThreshold: 3
           httpGet:
             path: /
-            port: 9738
+            port: pcm-metrics
             scheme: HTTP
           periodSeconds: 10
           successThreshold: 1
@@ -122,6 +122,26 @@ spec:
       - hostPath:
           path: /proc/sys/kernel/nmi_watchdog
         name: nmi-watchdog
+---
+# This networkPolicy lets anyone query the prometheus-metrics
+# PCM shouldn't have any outbound network trafic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: intel-pcm-sensor-server
+  namespace: intel-pcm
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: pcm-sensor-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: pcm-metrics
+  egress: []
 ---
 # prometheus operator defines this CRD
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
This sets a networkPolicy for pcm.  It is useful for environments where a default deny network policy is created. It further documents the behavior by using named ports within the pod.

This policy is easy to modify for folks who want to limit access to only the prometheus server.